### PR TITLE
feat: Add verify headers workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -44,6 +44,20 @@ jobs:
                     exit 1;
                 fi
 
+    verify-md-license:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            - name: Verify the MD footer
+              run: |-
+                cmd="grep -riL \"SPDX-License-Identifier: CC-BY-4.0\" --include=\*.md --exclude-dir={\*\openapi} ."
+                violations=$(eval $cmd | wc -l)
+                if [[ $violations -ne 0 ]] ; then
+                    echo "$violations files without license headers were found:";
+                    eval $cmd;
+                    exit 1;
+                fi
+
     Review-Allowed-Licenses:
         runs-on: ubuntu-latest
         continue-on-error: false

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,7 +50,7 @@ jobs:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: Verify the MD footer
               run: |-
-                cmd="find . -mindepth 2 -type f -exec grep -riL \"SPDX-License-Identifier: CC-BY-4.0\" --include=\*.md --exclude-dir={\*\openapi} ."
+                cmd="grep -riL \"SPDX-License-Identifier: CC-BY-4.0\" --include=\*.md --exclude-dir={\*\openapi} $(find . -mindepth 2 -type f)"
                 violations=$(eval $cmd | wc -l)
                 if [[ $violations -ne 0 ]] ; then
                     echo "$violations files without license headers were found:";

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,65 @@
+###############################################################
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+name: "Verify"
+
+# source: https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/blob/main/.github/workflows/verify.yaml
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+    verify-license-headers:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            - name: Verify License Headers
+              run: |-
+                cmd="grep -riL \"SPDX-License-Identifier: Apache-2.0\" --include=\*.{py,yaml,yml,sql} --exclude-dir={\*\openapi} ."
+                violations=$(eval $cmd | wc -l)
+                if [[ $violations -ne 0 ]] ; then
+                    echo "$violations files without license headers were found:";
+                    eval $cmd;
+                    exit 1;
+                fi
+
+    Review-Allowed-Licenses:
+        runs-on: ubuntu-latest
+        continue-on-error: false
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        steps:
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        - name: 'Check Allowed Licenses'
+          uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0
+          with:
+            fail-on-severity: critical
+          # Representation of this list: https://www.eclipse.org/legal/licenses.php#
+          # Expressed with the help of the following IDs: https://spdx.org/licenses/
+            allow-licenses: >-
+              Adobe-Glyph, Apache-1.0, Apache-1.1, Apache-2.0, Artistic-2.0, BSD-2-Clause, BSD-3-Clause,
+              BSD-4-Clause, 0BSD, BSL-1.0, CDDL-1.0, CDDL-1.1, CPL-1.0, CC-BY-3.0, CC-BY-4.0, CC-BY-2.5,
+              CC-BY-SA-3.0, CC-BY-SA-4.0, CC0-1.0, EPL-1.0, EPL-2.0, FTL, GFDL-1.3-only, IPL-1.0, ISC,
+              MIT, MIT-0, MPL-1.1, MPL-2.0, NTP, OpenSSL, PHP-3.01, PostgreSQL, OFL-1.1, Unlicense,
+              Unicode-DFS-2015, Unicode-DFS-2016, Unicode-TOU, UPL-1.0, W3C-20150513, W3C-19980720, W3C,
+              WTFPL, X11, Zlib, ZPL-2.1, AGPL-3.0

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,7 +50,7 @@ jobs:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: Verify the MD footer
               run: |-
-                cmd="grep -riL \"SPDX-License-Identifier: CC-BY-4.0\" --include=\*.md --exclude-dir={\*\openapi} ."
+                cmd="find . -mindepth 2 -type f -exec grep -riL \"SPDX-License-Identifier: CC-BY-4.0\" --include=\*.md --exclude-dir={\*\openapi} ."
                 violations=$(eval $cmd | wc -l)
                 if [[ $violations -ne 0 ]] ; then
                     echo "$violations files without license headers were found:";


### PR DESCRIPTION
## WHAT

Adds a header license checker workflow.

## WHY

To ensure that all files have the correct license header.

## FURTHER NOTES

Relates to https://github.com/eclipse-tractusx/industry-core-hub/issues/63