### PR TITLE
fix: Add the Missing License Header/Footer

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -1,3 +1,21 @@
+<!--
+
+Eclipse Tractus-X - Software Development KIT
+
+Copyright (c) 2025 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This work is made available under the terms of the
+Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+which is available at
+https://creativecommons.org/licenses/by/4.0/legalcode.
+
+SPDX-License-Identifier: CC-BY-4.0
+
+-->
+
 ## Use Case Extensions
 
 Using the Dataspace SDK and the Industry SDK here in this folder you have the posibility of including our specific backend add-on use case rules, so you can extend the funcionality of the SDK.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -25,3 +25,11 @@ Example:
 
 
 This code will be independant from the Industry Core Hub and will be supported by multiple applications that develop with the SDK.
+
+## NOTICE
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2025 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/tractusx-sdk


### PR DESCRIPTION
## WHAT

Add the missing license header/footer.

## WHY

To ensure that all files contain the appropriate license.