### PR TITLE
feat: Add put and delete methods to http_tools

### DIFF
--- a/src/tractusx_sdk/dataspace/tools/http_tools.py
+++ b/src/tractusx_sdk/dataspace/tools/http_tools.py
@@ -67,7 +67,37 @@ class HttpTools:
                             timeout=timeout,headers=headers,
                             data=data,json=json,
                             allow_redirects=allow_redirects)
-    
+
+    # do put request without session
+    def do_put(url, data=None, verify=False, headers=None, timeout=None, json=None, allow_redirects=False):
+        return requests.put(url=url, verify=verify,
+                            timeout=timeout, headers=headers,
+                            data=data, json=json,
+                            allow_redirects=allow_redirects)
+
+    # do put request with session
+    def do_put(url, session=None, data=None, verify=False, headers=None, timeout=None, json=None, allow_redirects=False):
+        if session is None:
+            session = requests.Session()
+        return session.put(url=url, verify=verify,
+                           timeout=timeout, headers=headers,
+                           data=data, json=json,
+                           allow_redirects=allow_redirects)
+
+    # do delete request without session
+    def do_delete(url, verify=False, headers=None, timeout=None, params=None, allow_redirects=False):
+        return requests.delete(url=url, verify=verify,
+                               timeout=timeout, headers=headers,
+                               params=params, allow_redirects=allow_redirects)
+
+    # do delete request with session
+    def do_delete(url, session=None, verify=False, headers=None, timeout=None, params=None, allow_redirects=False):
+        if session is None:
+            session = requests.Session()
+        return session.delete(url=url, verify=verify,
+                              timeout=timeout, headers=headers,
+                              params=params, allow_redirects=allow_redirects)
+
     # prepare response
     @staticmethod
     def response(data, status=200, content_type='application/json'):

--- a/src/tractusx_sdk/dataspace/tools/http_tools.py
+++ b/src/tractusx_sdk/dataspace/tools/http_tools.py
@@ -39,13 +39,13 @@ logger = logging.getLogger('staging')
 class HttpTools:
 
     # do get request without session
-    def do_get(url,verify=False,headers=None,timeout=None,params=None,allow_redirects=False):
+    def do_get(url,verify=True,headers=None,timeout=None,params=None,allow_redirects=False):
         return requests.get(url=url,verify=verify,
                             timeout=timeout,headers=headers,
                             params=params,allow_redirects=allow_redirects)
     
     # do get request with session
-    def do_get(url,session=None,verify=False,headers=None,timeout=None, params=None,allow_redirects=False):
+    def do_get(url,session=None,verify=True,headers=None,timeout=None, params=None,allow_redirects=False):
         if session is None:
             session = requests.Session()
         return session.get(url=url,verify=verify,
@@ -53,14 +53,14 @@ class HttpTools:
                            params=params,allow_redirects=allow_redirects)
     
     # do post request without session
-    def do_post(url,data=None,verify=False,headers=None,timeout=None,json=None,allow_redirects=False):
+    def do_post(url,data=None,verify=True,headers=None,timeout=None,json=None,allow_redirects=False):
         return requests.post(url=url,verify=verify,
                              timeout=timeout,headers=headers,
                              data=data,json=json,
                              allow_redirects=allow_redirects)
     
     # do post request with session
-    def do_post(url,session=None,data=None,verify=False,headers=None,timeout=None,json=None,allow_redirects=False):
+    def do_post(url,session=None,data=None,verify=True,headers=None,timeout=None,json=None,allow_redirects=False):
         if session is None:
             session = requests.Session()
         return session.post(url=url,verify=verify,
@@ -70,7 +70,7 @@ class HttpTools:
 
     # do put request without session
     @staticmethod
-    def do_put(url, data=None, verify=False, headers=None, timeout=None, json=None, allow_redirects=False):
+    def do_put(url, data=None, verify=True, headers=None, timeout=None, json=None, allow_redirects=False):
         return requests.put(url=url, verify=verify,
                             timeout=timeout, headers=headers,
                             data=data, json=json,
@@ -78,7 +78,7 @@ class HttpTools:
 
     # do put request with session
     @staticmethod
-    def do_put(url, session=None, data=None, verify=False, headers=None, timeout=None, json=None, allow_redirects=False):
+    def do_put(url, session=None, data=None, verify=True, headers=None, timeout=None, json=None, allow_redirects=False):
         if session is None:
             session = requests.Session()
         return session.put(url=url, verify=verify,
@@ -88,14 +88,14 @@ class HttpTools:
 
     # do delete request without session
     @staticmethod
-    def do_delete(url, verify=False, headers=None, timeout=None, params=None, allow_redirects=False):
+    def do_delete(url, verify=True, headers=None, timeout=None, params=None, allow_redirects=False):
         return requests.delete(url=url, verify=verify,
                                timeout=timeout, headers=headers,
                                params=params, allow_redirects=allow_redirects)
 
     # do delete request with session
     @staticmethod
-    def do_delete(url, session=None, verify=False, headers=None, timeout=None, params=None, allow_redirects=False):
+    def do_delete(url, session=None, verify=True, headers=None, timeout=None, params=None, allow_redirects=False):
         if session is None:
             session = requests.Session()
         return session.delete(url=url, verify=verify,

--- a/src/tractusx_sdk/dataspace/tools/http_tools.py
+++ b/src/tractusx_sdk/dataspace/tools/http_tools.py
@@ -69,6 +69,7 @@ class HttpTools:
                             allow_redirects=allow_redirects)
 
     # do put request without session
+    @staticmethod
     def do_put(url, data=None, verify=False, headers=None, timeout=None, json=None, allow_redirects=False):
         return requests.put(url=url, verify=verify,
                             timeout=timeout, headers=headers,
@@ -76,6 +77,7 @@ class HttpTools:
                             allow_redirects=allow_redirects)
 
     # do put request with session
+    @staticmethod
     def do_put(url, session=None, data=None, verify=False, headers=None, timeout=None, json=None, allow_redirects=False):
         if session is None:
             session = requests.Session()
@@ -85,12 +87,14 @@ class HttpTools:
                            allow_redirects=allow_redirects)
 
     # do delete request without session
+    @staticmethod
     def do_delete(url, verify=False, headers=None, timeout=None, params=None, allow_redirects=False):
         return requests.delete(url=url, verify=verify,
                                timeout=timeout, headers=headers,
                                params=params, allow_redirects=allow_redirects)
 
     # do delete request with session
+    @staticmethod
     def do_delete(url, session=None, verify=False, headers=None, timeout=None, params=None, allow_redirects=False):
         if session is None:
             session = requests.Session()

--- a/tests/dataspace/tools/test_http_tools.py
+++ b/tests/dataspace/tools/test_http_tools.py
@@ -72,6 +72,41 @@ class TestHttpTools(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), {"error": "Bad Request"})
 
+    @patch("requests.Session.put")
+    def test_do_put_success(self, mock_put):
+        """Test a successful PUT request."""
+        mock_put.return_value = Mock(status_code=200, json=lambda: {"message": "updated"})
+        
+        response = HttpTools.do_put(self.test_url, json=self.payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"message": "updated"})
+
+    @patch("requests.Session.put")
+    def test_do_put_failure(self, mock_put):
+        """Test PUT request with bad request response."""
+        mock_put.return_value = Mock(status_code=400, json=lambda: {"error": "Bad Request"})
+        
+        response = HttpTools.do_put(self.test_url, json=self.payload)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"error": "Bad Request"})
+
+    @patch("requests.Session.delete")
+    def test_do_delete_success(self, mock_delete):
+        """Test a successful DELETE request."""
+        mock_delete.return_value = Mock(status_code=204, json=lambda: {"message": "deleted"})
+        
+        response = HttpTools.do_delete(self.test_url)
+        self.assertEqual(response.status_code, 204)
+
+    @patch("requests.Session.delete")
+    def test_do_delete_failure(self, mock_delete):
+        """Test DELETE request with not found response."""
+        mock_delete.return_value = Mock(status_code=404, json=lambda: {"error": "Not Found"})
+        
+        response = HttpTools.do_delete(self.test_url)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(), {"error": "Not Found"})
+
     def test_response_json(self):
         """Ensure JSON response is properly structured."""
         response = HttpTools.response({"message": "OK"}, status=200)


### PR DESCRIPTION
* Added PUT and DELETE methods to the `tools/http_tools.py` file.

Related issue #39 

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
