### PR TITLE
fix(AasService) return Result schema for not 2XX responses

### DIFF
--- a/src/tractusx_sdk/industry/models/__init__.py
+++ b/src/tractusx_sdk/industry/models/__init__.py
@@ -34,6 +34,7 @@ from .abstract_aas import (
     ReferenceTypes,
     ReferenceKeyTypes,
     ProtocolInformationSecurityAttributesTypes,
+    MessageTypeEnum,
     # Basic models
     BaseAbstractModel,
     AbstractMultiLanguage,
@@ -45,6 +46,7 @@ from .abstract_aas import (
     AbstractAdministrativeInformation,
     AbstractEndpoint,
     AbstractSpecificAssetId,
+    AbstractMessage,
     # Major models
     AbstractSubModelDescriptor,
     AbstractShellDescriptor,
@@ -53,4 +55,5 @@ from .abstract_aas import (
     AbstractPaginatedResponse,
     AbstractGetAllShellDescriptorsResponse,
     AbstractGetSubmodelDescriptorsByAssResponse,
+    AbstractResult,
 )

--- a/src/tractusx_sdk/industry/models/abstract_aas.py
+++ b/src/tractusx_sdk/industry/models/abstract_aas.py
@@ -50,6 +50,7 @@ TSubModelDesc = TypeVar("TSubModelDesc", bound="AbstractSubModelDescriptor")
 TSpecificAssetId = TypeVar("TSpecificAssetId", bound="AbstractSpecificAssetId")
 TPagingMetadata = TypeVar("TPagingMetadata", bound="AbstractPagingMetadata")
 TShellDescriptor = TypeVar("TShellDescriptor", bound="AbstractShellDescriptor")
+TMessage = TypeVar("TMessage", bound="AbstractMessage")
 
 
 class BaseAbstractModel(BaseModel, ABC):
@@ -136,6 +137,15 @@ class ProtocolInformationSecurityAttributesTypes(str, Enum):
     NONE = "NONE"
     RFC_TLSA = "RFC_TLSA"
     W3C_DID = "W3C_DID"
+
+class MessageTypeEnum(str, Enum):
+    """Enum for message types."""
+
+    UNDEFINED = "Undefined"
+    INFO = "Info"
+    WARNING = "Warning"
+    ERROR = "Error"
+    EXCEPTION = "Exception"
 
 
 class AbstractReferenceKey(BaseAbstractModel):
@@ -434,3 +444,27 @@ class AbstractGetSubmodelDescriptorsByAssResponse(
     """
 
     result: List[TSubModelDesc]
+
+class AbstractMessage(BaseAbstractModel):
+    """
+    Abstract class for message in a not 2XX response.
+    This class should not be used directly. Instead, use a version-specific implementation.
+    Supported versions extend this class with modifications specific to that API version.
+    Extending classes can add additional version-specific configuration.
+    """
+
+    code: str | None = Field(None)
+    correlationId: str | None = Field(None)
+    messageType: MessageTypeEnum | None = Field(None)
+    text: str | None = Field(None)
+    timestamp: str | None = Field(None)
+
+class AbstractResult(BaseAbstractModel, Generic[TMessage]):
+    """
+    Abstract class for result in a not 2XX response.
+    This class should not be used directly. Instead, use a version-specific implementation.
+    Supported versions extend this class with modifications specific to that API version.
+    Extending classes can add additional version-specific configuration.
+    """
+
+    messages: List[TMessage] | None = Field(None)

--- a/src/tractusx_sdk/industry/models/v3/aas.py
+++ b/src/tractusx_sdk/industry/models/v3/aas.py
@@ -39,6 +39,8 @@ from tractusx_sdk.industry.models import (
     AbstractPagingMetadata,
     AbstractGetAllShellDescriptorsResponse,
     AbstractGetSubmodelDescriptorsByAssResponse,
+    AbstractMessage,
+    AbstractResult,
 )
 from tractusx_sdk.industry.models import (
     AASSupportedVersionsEnum,
@@ -107,6 +109,16 @@ class ProtocolInformationSecurityAttributesTypes(str, Enum):
     NONE = "NONE"
     RFC_TLSA = "RFC_TLSA"
     W3C_DID = "W3C_DID"
+
+
+class MessageTypeEnum(str, Enum):
+    """Enum for message types. AAS 3.0 specification."""
+
+    UNDEFINED = "Undefined"
+    INFO = "Info"
+    WARNING = "Warning"
+    ERROR = "Error"
+    EXCEPTION = "Exception"
 
 
 class ReferenceKey(AbstractReferenceKey, VersionedModel):
@@ -219,5 +231,21 @@ class GetSubmodelDescriptorsByAssResponse(
     AbstractGetSubmodelDescriptorsByAssResponse[PagingMetadata, SubModelDescriptor],
 ):
     """Response model for the get_submodel_descriptors method following the AAS 3.0 specification."""
+
+    pass
+
+
+class Message(AbstractMessage):
+    """
+    Abstract class for message in a not 2XX response following the AAS 3.0 specification.
+    """
+
+    pass
+
+
+class Result(AbstractResult[Message]):
+    """
+    Abstract class for result in a not 2XX response following the AAS 3.0 specification.
+    """
 
     pass


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
This PR fixes DTR service not 2XX responses.

In the AAS spec definition, if a request is not succesful (not 2XX), the service is spected to return a message containing details about the failure.
An error should only be raised if it's network related 

In our current implementation instead of returning this meesage, we raise an error if the DTR response is not 2XX, returning an 500 status code instead of the DTR message.

![Screenshot from 2025-03-20 14-34-12](https://github.com/user-attachments/assets/394a52cf-6f41-4d5a-b234-5e624c481f91)
![Screenshot from 2025-03-20 14-34-36](https://github.com/user-attachments/assets/e8c2221f-083b-4a93-b445-4bbba6aadee4)

As our service doesn't implement any business logic to handle the requests, it should resturn the response instead of a misleading 500 response.

This PR fixes the issue returning that message.
![Screenshot from 2025-03-20 14-32-55](https://github.com/user-attachments/assets/b7ec4259-ac2e-4c67-98ae-e4009657ca96)


<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
@mgarciaLKS PR #55 might need some adjustment to implement this fix
## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
