### PR TITLE
fix: windows PyPi package installation supported

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -27,11 +27,12 @@ on:
   workflow_dispatch:
 
 env:
-  POETRY_HOME: /opt/poetry
+  POETRY_HOME_UNIX: /opt/poetry
+  POETRY_HOME_WINDOWS: C:\poetry
   POETRY_VERSION: 2.0.0
 
 jobs:
-  check-dependencies-backend:
+  check-dependencies-backend-unix:
     runs-on: ubuntu-latest
 
     steps:
@@ -55,9 +56,9 @@ jobs:
       # https://python-poetry.org/docs/#ci-recommendations
       - name: Create a venv for Poetry and install Poetry
         run: |
-          python3 -m venv $POETRY_HOME
-          $POETRY_HOME/bin/pip install poetry==$POETRY_VERSION
-          $POETRY_HOME/bin/poetry --version
+          python3 -m venv $POETRY_HOME_UNIX
+          $POETRY_HOME_UNIX/bin/pip install poetry==$POETRY_VERSION
+          $POETRY_HOME_UNIX/bin/poetry --version
 
       # Poetry sync is preferred over install because it makes sure to be in sync with the poetry.lock file
       # We use --no-root to avoid installing the current package in the virtual environment
@@ -65,14 +66,14 @@ jobs:
       - name: Install dependencies
         run: |
           if [ -f poetry.lock ]; then
-            $POETRY_HOME/bin/poetry sync --no-root
+            $POETRY_HOME_UNIX/bin/poetry sync --no-root
           else
-            $POETRY_HOME/bin/poetry install --no-root
+            $POETRY_HOME_UNIX/bin/poetry install --no-root
           fi
 
       - name: List packages
         run: |
-             $POETRY_HOME/bin/poetry run pip list --format=freeze | grep -Pv "^(pip|setuptools|wheel|virtualenv|distlib|pkg_resources)" | awk -F'==' '{print "pypi/pypi/-/" $1 "/" $2}' | awk '!seen[$0]++' > PACKAGE
+             $POETRY_HOME_UNIX/bin/poetry run pip list --format=freeze | grep -Pv "^(pip|setuptools|wheel|virtualenv|distlib|pkg_resources)" | awk -F'==' '{print "pypi/pypi/-/" $1 "/" $2}' | awk '!seen[$0]++' > PACKAGE
 
       - name: Generate Dependencies file
         run: |
@@ -109,3 +110,93 @@ jobs:
         with:
             path: $DEP_FILE
 
+  check-dependencies-backend-windows:
+      runs-on: windows-latest
+      defaults:
+            run:
+              shell: pwsh
+      steps:
+
+        - name: Checkout repository
+          uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+        - name: Set up JDK 21
+          uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
+          with:
+            distribution: 'temurin'
+            java-version: '21'
+      
+        - name: Set up Python
+          uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+          with:
+              python-version: '3.12'
+
+        # We don't need to create a python virtual environment because Poetry already handles it for us
+        # Poetry is installed in a separate virtual environment because it is highly recommended
+        # https://python-poetry.org/docs/#ci-recommendations
+        - name: Create a venv for Poetry and install Poetry - Pwsh version
+          run: |
+            python -m venv $env:POETRY_HOME_WINDOWS
+            & "$env:POETRY_HOME_WINDOWS\Scripts\pip" install poetry==$env:POETRY_VERSION
+            & "$env:POETRY_HOME_WINDOWS\Scripts\poetry" --version
+
+
+        # Poetry sync is preferred over install because it makes sure to be in sync with the poetry.lock file
+        # We use --no-root to avoid installing the current package in the virtual environment
+        # If the poetry.lock file is not present, we use install as a fallback
+        - name: Install dependencies - Pwsh version
+          run: |
+            if (Test-Path poetry.lock) {
+              & "$env:POETRY_HOME_WINDOWS\Scripts\poetry" sync --no-root
+            } 
+            else {
+              & "$env:POETRY_HOME_WINDOWS\Scripts\poetry" install --no-root
+            }
+
+        - name: List packages - Pwsh version
+          run: |
+              & "$env:POETRY_HOME_WINDOWS\Scripts\poetry" run pip list --format=freeze | 
+              Where-Object { $_ -notmatch '^(pip|setuptools|wheel|virtualenv|distlib|pkg_resources)' } | 
+              ForEach-Object { 
+                $parts = $_ -split '=='
+                "pypi/pypi/-/$($parts[0])/$($parts[1])"
+              } | 
+              Get-Unique | 
+              Out-File -FilePath PACKAGE
+
+        - name: Generate Dependencies file - Pwsh version
+          run: |
+              Invoke-WebRequest -Uri 'https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST' -OutFile .\dash.jar
+
+              $DEP_FILE = "DEPENDENCIES_TRACTUS-X_SDK"
+
+              echo "DEP_FILE=$DEP_FILE" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+              java -jar .\dash.jar PACKAGE -project automotive.tractusx -summary $DEP_FILE
+              if ($LASTEXITCODE -ne 0) { $LASTEXITCODE = 0 }
+
+        - name: Check if dependencies were changed - Pwsh version
+          id: dependencies-changed
+          run: |
+              git diff --exit-code $env:DEP_FILE
+              if ($LASTEXITCODE -eq 0) {
+                  echo "changed=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+              } else {
+                  echo "changed=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+                  echo "Change the $env:DEP_FILE with these new dependencies"
+                  Get-Content $env:DEP_FILE
+                  exit 1
+              }
+
+        - name: Check for restricted dependencies - Pwsh version
+          run: |
+              $restricted = Select-String -Path $env:DEP_FILE -Pattern 'restricted' -ErrorAction SilentlyContinue
+              if ($restricted) {
+                  Write-Error "The following dependencies are restricted: $restricted"
+                  exit 1
+              }
+
+        - name: Upload dependency file - Pwsh version
+          uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+          with:
+            path: ${{ env.DEP_FILE }}

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -168,7 +168,7 @@ jobs:
           run: |
               Invoke-WebRequest -Uri 'https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST' -OutFile .\dash.jar
 
-              $DEP_FILE = "DEPENDENCIES_TRACTUS-X_SDK"
+              $DEP_FILE = "DEPENDENCIES_TRACTUS-X_SDK_WINDOWS"
 
               echo "DEP_FILE=$DEP_FILE" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 

--- a/DEPENDENCIES_TRACTUS-X_SDK_WINDOWS
+++ b/DEPENDENCIES_TRACTUS-X_SDK_WINDOWS
@@ -1,0 +1,60 @@
+pypi/pypi/-/Jinja2/3.1.4, BSD-3-Clause, approved, #7978
+pypi/pypi/-/MarkupSafe/2.0.1, BSD-2-Clause AND BSD-3-Clause, approved, clearlydefined
+pypi/pypi/-/PyYAML/6.0.2, MIT, approved, clearlydefined
+pypi/pypi/-/Pygments/2.19.1, , approved, #19382
+pypi/pypi/-/SQLAlchemy/2.0.38, MIT AND LGPL-2.0-only AND BSD-3-Clause AND LGPL-2.0-or-later, approved, #19392
+pypi/pypi/-/annotated-types/0.7.0, MIT, approved, clearlydefined
+pypi/pypi/-/anyio/4.8.0, MIT, approved, #19384
+pypi/pypi/-/build/1.2.2.post1, MIT, approved, clearlydefined
+pypi/pypi/-/certifi/2023.7.22, MPL-2.0, approved, #19826
+pypi/pypi/-/cffi/1.17.1, MIT, approved, #19388
+pypi/pypi/-/charset-normalizer/3.4.1, MIT AND (LGPL-2.1-only AND MIT) AND LGPL-2.1-only AND CC-BY-SA-3.0, approved, #19391
+pypi/pypi/-/click/8.1.8, BSD-2-Clause AND BSD-3-Clause, approved, clearlydefined
+pypi/pypi/-/colorama/0.4.6, BSD-2-Clause AND BSD-3-Clause, approved, clearlydefined
+pypi/pypi/-/cryptography/44.0.1, Apache-2.0 AND BSD-3-Clause AND Apache-2.0 AND BSD-3-Clause AND (BSD-3-Clause AND MIT), approved, #19520
+pypi/pypi/-/deprecation/2.1.0, Apache-2.0 AND BSD-3-Clause AND MIT, approved, #7823
+pypi/pypi/-/dnspython/2.7.0, ISC, approved, #19394
+pypi/pypi/-/email_validator/2.2.0, Unlicense, approved, #19387
+pypi/pypi/-/exceptiongroup/1.2.2, MIT AND PSF-2.0, approved, #12076
+pypi/pypi/-/fastapi-cli/0.0.7, MIT, approved, clearlydefined
+pypi/pypi/-/fastapi-keycloak-middleware/1.1.0, MIT, approved, clearlydefined
+pypi/pypi/-/fastapi/0.115.7, MIT, approved, #19828
+pypi/pypi/-/greenlet/3.1.1, MIT AND PSF-2.0, approved, #19389
+pypi/pypi/-/h11/0.14.0, MIT AND BSD-3-Clause, approved, #13077
+pypi/pypi/-/httpcore/0.16.3, BSD-2-Clause AND BSD-3-Clause, approved, clearlydefined
+pypi/pypi/-/httptools/0.6.4, MIT, approved, #14635
+pypi/pypi/-/httpx/0.23.1, BSD-2-Clause AND BSD-3-Clause, approved, clearlydefined
+pypi/pypi/-/idna/3.3, BSD-3-Clause AND LicenseRef-scancode-unicode, approved, #4826
+pypi/pypi/-/iniconfig/2.0.0, MIT, approved, clearlydefined
+pypi/pypi/-/jwcrypto/1.5.6, LGPL-3.0-only AND LGPL-3.0-or-later, approved, #15152
+pypi/pypi/-/markdown-it-py/3.0.0, MIT, approved, clearlydefined
+pypi/pypi/-/mdurl/0.1.2, MIT, approved, clearlydefined
+pypi/pypi/-/packaging/24.1, Apache-2.0 AND BSD-3-Clause, approved, clearlydefined
+pypi/pypi/-/pluggy/1.5.0, MIT, approved, clearlydefined
+pypi/pypi/-/pycparser/2.22, LGPL-2.0-or-later AND BSD-3-Clause, approved, #14636
+pypi/pypi/-/pydantic/2.6.3, MIT, approved, #13069
+pypi/pypi/-/pydantic_core/2.16.3, MIT, approved, clearlydefined
+pypi/pypi/-/pyproject_hooks/1.2.0, MIT, approved, clearlydefined
+pypi/pypi/-/pytest-asyncio/0.15.1, Apache-2.0, approved, clearlydefined
+pypi/pypi/-/pytest/8.1.1, MIT, approved, #19365
+pypi/pypi/-/python-dotenv/1.0.1, BSD-2-Clause AND BSD-3-Clause, approved, clearlydefined
+pypi/pypi/-/python-keycloak/4.0.1, MIT, approved, clearlydefined
+pypi/pypi/-/python-multipart/0.0.20, Apache-2.0, approved, clearlydefined
+pypi/pypi/-/requests-mock/1.12.1, Apache-2.0, approved, clearlydefined
+pypi/pypi/-/requests-toolbelt/1.0.0, Apache-2.0, approved, #15024
+pypi/pypi/-/requests/2.32.3, Apache-2.0 AND MIT AND Apache-2.0, approved, #14884
+pypi/pypi/-/rfc3986/1.5.0, Apache-2.0, approved, #19390
+pypi/pypi/-/rich-toolkit/0.13.2, MIT, approved, clearlydefined
+pypi/pypi/-/rich/13.9.4, MIT, approved, clearlydefined
+pypi/pypi/-/shellingham/1.5.4, ISC AND BSD-3-Clause, approved, #19381
+pypi/pypi/-/sniffio/1.3.1, Apache-2.0 OR (Apache-2.0 AND MIT), approved, clearlydefined
+pypi/pypi/-/sqlmodel/0.0.22, MIT, approved, clearlydefined
+pypi/pypi/-/starlette/0.40.0, BSD-2-Clause AND BSD-3-Clause, approved, clearlydefined
+pypi/pypi/-/tomli/2.0.1, MIT, approved, #7824
+pypi/pypi/-/typer/0.15.1, MIT, approved, clearlydefined
+pypi/pypi/-/typing_extensions/4.12.2, Python-2.0, approved, #19383
+pypi/pypi/-/urllib3/2.3.0, MIT AND Python-2.0 AND MPL-2.0, approved, #19863
+pypi/pypi/-/uvicorn/0.30.3, BSD-2-Clause AND BSD-3-Clause, approved, clearlydefined
+pypi/pypi/-/watchfiles/1.0.4, MIT, approved, clearlydefined
+pypi/pypi/-/websockets/14.2, BSD-3-Clause AND (Apache-2.0 AND PSF-2.0), approved, #19393
+pypi/pypi/-/winloop/0.1.8, Apache-2.0 AND MIT AND ISC AND CC-BY-4.0 AND BSD-2-Clause AND (GPL-3.0-or-later WITH Autoconf-exception-macro), approved, #20508

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,10 @@ dependencies = [
     "typing-extensions (==4.12.2)",
     "urllib3 (==2.3.0)",
     "uvicorn (==0.30.3)",
-    "uvloop (==0.21.0)",
+
+    "uvloop(==0.21.0); sys_platform == 'linux' or sys_platform == 'darwin'",
+    "winloop(==0.1.8); sys_platform == 'win32'",
+    
     "watchfiles (==1.0.4)",
     "websockets (==14.2)"
 ]


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This PR introduces a modification in the pyproject.toml file to make tractusx-sdk installation possible in Windows, by using winloop instead of uvloop library when windows os detected.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Fixes #51 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
