### PR TITLE
fix: bad test imports

### DIFF
--- a/tests/dataspace/adapters/connector/test_adapter_factory.py
+++ b/tests/dataspace/adapters/connector/test_adapter_factory.py
@@ -23,7 +23,7 @@
 import unittest
 from enum import Enum
 from unittest.mock import patch
-from src.tractusx_sdk.dataspace.adapters.connector.adapter_factory import AdapterFactory, AdapterType
+from tractusx_sdk.dataspace.adapters.connector.adapter_factory import AdapterFactory, AdapterType
 
 
 class TestAdapterFactory(unittest.TestCase):

--- a/tests/dataspace/adapters/connector/test_base_dma_adapter.py
+++ b/tests/dataspace/adapters/connector/test_base_dma_adapter.py
@@ -21,7 +21,7 @@
 #################################################################################
 
 import unittest
-from src.tractusx_sdk.dataspace.adapters.connector.base_dma_adapter import BaseDmaAdapter
+from tractusx_sdk.dataspace.adapters.connector.base_dma_adapter import BaseDmaAdapter
 
 
 class TestBaseDmaAdapter(unittest.TestCase):

--- a/tests/dataspace/adapters/test_adapter.py
+++ b/tests/dataspace/adapters/test_adapter.py
@@ -24,7 +24,7 @@ import unittest
 import requests_mock
 from json import loads as jloads
 
-from src.tractusx_sdk.dataspace.adapters.adapter import Adapter
+from tractusx_sdk.dataspace.adapters.adapter import Adapter
 
 
 class TestAdapter(unittest.TestCase):

--- a/tests/dataspace/models/connector/test_base_asset_model.py
+++ b/tests/dataspace/models/connector/test_base_asset_model.py
@@ -23,7 +23,7 @@
 import unittest
 from pydantic import ValidationError
 
-from src.tractusx_sdk.dataspace.models.connector.base_asset_model import BaseAssetModel
+from tractusx_sdk.dataspace.models.connector.base_asset_model import BaseAssetModel
 
 
 class ConcreteAssetModel(BaseAssetModel):

--- a/tests/dataspace/models/connector/test_base_contract_definition_model.py
+++ b/tests/dataspace/models/connector/test_base_contract_definition_model.py
@@ -23,7 +23,7 @@
 import unittest
 from pydantic import ValidationError
 
-from src.tractusx_sdk.dataspace.models.connector.base_contract_definition_model import BaseContractDefinitionModel
+from tractusx_sdk.dataspace.models.connector.base_contract_definition_model import BaseContractDefinitionModel
 
 
 class ConcreteContractDefinitionModel(BaseContractDefinitionModel):

--- a/tests/dataspace/models/connector/test_base_policy_model.py
+++ b/tests/dataspace/models/connector/test_base_policy_model.py
@@ -23,7 +23,7 @@
 import unittest
 from pydantic import ValidationError
 
-from src.tractusx_sdk.dataspace.models.connector.base_policy_model import BasePolicyModel
+from tractusx_sdk.dataspace.models.connector.base_policy_model import BasePolicyModel
 
 
 class ConcretePolicyModel(BasePolicyModel):

--- a/tests/dataspace/models/connector/test_model_factory.py
+++ b/tests/dataspace/models/connector/test_model_factory.py
@@ -23,7 +23,7 @@
 import unittest
 from enum import Enum
 from unittest.mock import patch
-from src.tractusx_sdk.dataspace.models.connector.model_factory import ModelFactory, ModelType
+from tractusx_sdk.dataspace.models.connector.model_factory import ModelFactory, ModelType
 
 
 class TestModelFactory(unittest.TestCase):

--- a/tests/dataspace/models/connector/test_model_factory_asset.py
+++ b/tests/dataspace/models/connector/test_model_factory_asset.py
@@ -22,7 +22,7 @@
 
 import unittest
 
-from src.tractusx_sdk.dataspace.models.connector.model_factory import ModelFactory
+from tractusx_sdk.dataspace.models.connector.model_factory import ModelFactory
 
 
 class TestModelFactoryAsset(unittest.TestCase):

--- a/tests/dataspace/models/connector/test_model_factory_catalog.py
+++ b/tests/dataspace/models/connector/test_model_factory_catalog.py
@@ -23,9 +23,9 @@
 import unittest
 from unittest.mock import Mock, MagicMock
 
-from src.tractusx_sdk.dataspace.models.connector.base_catalog_model import BaseCatalogModel
-from src.tractusx_sdk.dataspace.models.connector.base_queryspec_model import BaseQuerySpecModel
-from src.tractusx_sdk.dataspace.models.connector.model_factory import ModelFactory
+from tractusx_sdk.dataspace.models.connector.base_catalog_model import BaseCatalogModel
+from tractusx_sdk.dataspace.models.connector.base_queryspec_model import BaseQuerySpecModel
+from tractusx_sdk.dataspace.models.connector.model_factory import ModelFactory
 
 
 class TestModelFactoryCatalog(unittest.TestCase):

--- a/tests/dataspace/models/connector/test_model_factory_contract_definition.py
+++ b/tests/dataspace/models/connector/test_model_factory_contract_definition.py
@@ -22,8 +22,8 @@
 
 import unittest
 
-from src.tractusx_sdk.dataspace.models.connector.base_contract_definition_model import BaseContractDefinitionModel
-from src.tractusx_sdk.dataspace.models.connector.model_factory import ModelFactory
+from tractusx_sdk.dataspace.models.connector.base_contract_definition_model import BaseContractDefinitionModel
+from tractusx_sdk.dataspace.models.connector.model_factory import ModelFactory
 
 
 class TestModelFactoryContractDefinition(unittest.TestCase):

--- a/tests/dataspace/models/connector/test_model_factory_contract_negotiation.py
+++ b/tests/dataspace/models/connector/test_model_factory_contract_negotiation.py
@@ -26,9 +26,9 @@ from unittest.mock import MagicMock, Mock
 
 from pydantic import ValidationError
 
-from src.tractusx_sdk.dataspace.models.connector.base_contract_negotiation_model import BaseContractNegotiationModel
-from src.tractusx_sdk.dataspace.models.connector.base_policy_model import BasePolicyModel
-from src.tractusx_sdk.dataspace.models.connector.model_factory import ModelFactory
+from tractusx_sdk.dataspace.models.connector.base_contract_negotiation_model import BaseContractNegotiationModel
+from tractusx_sdk.dataspace.models.connector.base_policy_model import BasePolicyModel
+from tractusx_sdk.dataspace.models.connector.model_factory import ModelFactory
 
 
 class TestModelFactoryContractNegotiation(unittest.TestCase):

--- a/tests/dataspace/models/connector/test_model_factory_policy.py
+++ b/tests/dataspace/models/connector/test_model_factory_policy.py
@@ -22,8 +22,8 @@
 
 import unittest
 
-from src.tractusx_sdk.dataspace.models.connector.base_policy_model import BasePolicyModel
-from src.tractusx_sdk.dataspace.models.connector.model_factory import ModelFactory
+from tractusx_sdk.dataspace.models.connector.base_policy_model import BasePolicyModel
+from tractusx_sdk.dataspace.models.connector.model_factory import ModelFactory
 
 
 class TestModelFactoryPolicy(unittest.TestCase):

--- a/tests/dataspace/models/connector/test_model_factory_queryspec.py
+++ b/tests/dataspace/models/connector/test_model_factory_queryspec.py
@@ -22,8 +22,8 @@
 
 import unittest
 
-from src.tractusx_sdk.dataspace.models.connector.base_queryspec_model import BaseQuerySpecModel
-from src.tractusx_sdk.dataspace.models.connector.model_factory import ModelFactory
+from tractusx_sdk.dataspace.models.connector.base_queryspec_model import BaseQuerySpecModel
+from tractusx_sdk.dataspace.models.connector.model_factory import ModelFactory
 
 
 class TestModelFactoryQuerySpec(unittest.TestCase):

--- a/tests/dataspace/models/connector/test_model_factory_transfer_process.py
+++ b/tests/dataspace/models/connector/test_model_factory_transfer_process.py
@@ -22,8 +22,8 @@
 
 import unittest
 
-from src.tractusx_sdk.dataspace.models.connector.base_transfer_process_model import BaseTransferProcessModel
-from src.tractusx_sdk.dataspace.models.connector.model_factory import ModelFactory
+from tractusx_sdk.dataspace.models.connector.base_transfer_process_model import BaseTransferProcessModel
+from tractusx_sdk.dataspace.models.connector.model_factory import ModelFactory
 
 
 class TestModelFactoryTransferProcess(unittest.TestCase):


### PR DESCRIPTION
## WHAT

This PR fixes bad imports that are present on some test files

## WHY

According to https://github.com/eclipse-tractusx/tractusx-sdk/issues/6#issuecomment-2713233603, imports should be used directly from `tractusx_sdk`, and not from `src.tractusx_sdk`. This PR fixes this issue.