### PR TITLE
feat: Add Submodel Server Adapter and FileSystemAdapter

### DIFF
--- a/src/tractusx_sdk/dataspace/tools/operators.py
+++ b/src/tractusx_sdk/dataspace/tools/operators.py
@@ -351,3 +351,14 @@ class op:
             bool: True if the path is a symbolic link, False otherwise.
         """
         return os.path.islink(path)
+
+    @staticmethod
+    def is_file(path: str) -> bool:
+        """
+        Check if the given path corresponds to an existing file.
+        Args:
+            path (str): The path to check.
+        Returns:
+            bool: True if the path corresponds to an existing file, False otherwise.
+        """
+        return os.path.isfile(path=path)

--- a/src/tractusx_sdk/dataspace/tools/operators.py
+++ b/src/tractusx_sdk/dataspace/tools/operators.py
@@ -313,3 +313,41 @@ class op:
             source_object=source_object[part]
         tmp_ret=source_object
         return tmp_ret
+
+    @staticmethod
+    def join_paths(path_one: str, path_two: str) -> str:
+        """
+        Joins two file system paths into a single path.
+        Args:
+            path_one (str): The first path component.
+            path_two (str): The second path component.
+        Returns:
+            str: The combined file system path.
+        """
+        return os.path.join(path_one,path_two)
+    
+    @staticmethod
+    def list_directories(directory_path: str) -> list:
+        """
+        Lists all entries in the specified directory.
+        Args:
+            directory_path (str): The path to the directory whose entries are to be listed.
+        Returns:
+            list: A list of names of the entries in the directory.
+        Raises:
+            FileNotFoundError: If the specified directory does not exist.
+            NotADirectoryError: If the specified path is not a directory.
+            PermissionError: If the program does not have permission to access the directory.
+        """
+        return os.listdir(directory_path)
+    
+    @staticmethod
+    def is_link(path: str) -> bool:
+        """
+        Check if the given path is a symbolic link.
+        Args:
+            path (str): The file system path to check.
+        Returns:
+            bool: True if the path is a symbolic link, False otherwise.
+        """
+        return os.path.islink(path)

--- a/src/tractusx_sdk/industry/adapters/__init__.py
+++ b/src/tractusx_sdk/industry/adapters/__init__.py
@@ -1,0 +1,24 @@
+#################################################################################
+# Eclipse Tractus-X - Software Development KIT
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from .submodel_adapter import SubmodelAdapter
+from .submodel_adapter_factory import SubmodelAdapterFactory

--- a/src/tractusx_sdk/industry/adapters/submodel_adapter.py
+++ b/src/tractusx_sdk/industry/adapters/submodel_adapter.py
@@ -1,0 +1,78 @@
+#################################################################################
+# Eclipse Tractus-X - Software Development KIT
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from abc import ABC, abstractmethod
+from typing import List
+
+class SubmodelAdapter(ABC):
+    """
+    Submodel Adapter class
+    """
+
+    @abstractmethod
+    def read(self, path: str):
+        """
+        Return the entire content of a file
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def write(self, path: str, content: bytes) -> None:
+        """
+        Write a new file
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete(self, path: str) -> None:
+        """
+        Delete a specific file
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def exists(self, path: str) -> bool:
+        """
+        Check if a file exists
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_contents(self, directory_path: str) -> List[dict]:
+        """
+        Return a list of files based in a directory
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def create_directory(self, path: str) -> None:
+        """
+        Create a directory
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete_directory(self, path: str) -> None:
+        """
+        Remove a directory
+        """
+        raise NotImplementedError

--- a/src/tractusx_sdk/industry/adapters/submodel_adapter.py
+++ b/src/tractusx_sdk/industry/adapters/submodel_adapter.py
@@ -56,23 +56,3 @@ class SubmodelAdapter(ABC):
         """
         raise NotImplementedError
 
-    @abstractmethod
-    def list_contents(self, directory_path: str) -> List[dict]:
-        """
-        Return a list of files based in a directory
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def create_directory(self, path: str) -> None:
-        """
-        Create a directory
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def delete_directory(self, path: str) -> None:
-        """
-        Remove a directory
-        """
-        raise NotImplementedError

--- a/src/tractusx_sdk/industry/adapters/submodel_adapter.py
+++ b/src/tractusx_sdk/industry/adapters/submodel_adapter.py
@@ -21,7 +21,6 @@
 #################################################################################
 
 from abc import ABC, abstractmethod
-from typing import List
 
 class SubmodelAdapter(ABC):
     """
@@ -55,4 +54,3 @@ class SubmodelAdapter(ABC):
         Check if a file exists
         """
         raise NotImplementedError
-

--- a/src/tractusx_sdk/industry/adapters/submodel_adapter_factory.py
+++ b/src/tractusx_sdk/industry/adapters/submodel_adapter_factory.py
@@ -1,0 +1,62 @@
+#################################################################################
+# Eclipse Tractus-X - Software Development KIT
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from enum import Enum
+from importlib import import_module
+
+class SubmodelAdapterType(Enum):
+    """
+    Enum for different adapter types. Each adapter type corresponds to a specific implementation,
+    and must correspond exactly to the prefix of the adapter class it is associated with.
+    """
+    FILE_SYSTEM = "FileSystem"
+
+class SubmodelAdapterFactory:
+
+    @staticmethod
+    def _get_adapter_builder(
+            adapter_type: SubmodelAdapterType,
+    ):
+        adapter_module = ".".join(__name__.split(".")[0:-1])
+        module_name = f"{adapter_module}.submodel_adapters"
+        adapter_class_name = f"{adapter_type.value}Adapter"     
+
+        try:
+            module = import_module(module_name)
+            adapter_class = getattr(module, adapter_class_name)
+            return adapter_class.builder()
+        except AttributeError as attr_exception:
+            raise AttributeError(
+                f"Failed to import adapter class {adapter_class_name} for module {module_name}"
+            ) from attr_exception
+        except ImportError as import_exception:
+            raise ImportError(
+                f"Failed to import module {module_name}. Ensure that the required packages are installed and the PYTHONPATH is set correctly."
+            ) from import_exception
+    
+    @staticmethod
+    def get_file_system(root_path: str = "./submodel"):
+        builder = SubmodelAdapterFactory._get_adapter_builder(
+            adapter_type=SubmodelAdapterType.FILE_SYSTEM,
+        )
+        builder.root_path(root_path)
+        return builder.build()

--- a/src/tractusx_sdk/industry/adapters/submodel_adapters/__init__.py
+++ b/src/tractusx_sdk/industry/adapters/submodel_adapters/__init__.py
@@ -1,0 +1,27 @@
+#################################################################################
+# Eclipse Tractus-X - Software Development KIT
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from .file_system_adapter import FileSystemAdapter
+
+__all__ = [
+    'FileSystemAdapter'
+]

--- a/src/tractusx_sdk/industry/adapters/submodel_adapters/file_system_adapter.py
+++ b/src/tractusx_sdk/industry/adapters/submodel_adapters/file_system_adapter.py
@@ -1,0 +1,111 @@
+#################################################################################
+# Eclipse Tractus-X - Software Development KIT
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from .. import SubmodelAdapter
+from tractusx_sdk.dataspace.tools import op
+from typing import List
+
+class FileSystemAdapter(SubmodelAdapter):
+
+    def __init__(self, root_path: str):
+        self.root_path = root_path
+        print("FileSystem initilized")
+
+    @classmethod
+    def builder(cls):
+        return cls._Builder(cls)
+
+    class _Builder:
+        def __init__(self, cls):
+            self.cls = cls
+            self._data = {}
+
+        def root_path(self, path:str):
+            self._data["root_path"] = path
+            return self
+        
+        def build(self):
+            if "root_path" not in self._data:
+                raise ValueError("Missing required buider parameter: root_path")
+            return self.cls(**self._data)
+    
+
+    def read(self, path: str):
+        """
+        Return the entire content of a file
+        """
+        total_path = op.join_paths(self.root_path, path)
+        return op.read_json_file(total_path)
+         
+
+    def write(self, path: str, content) -> None:
+        """
+        Write a new file
+        """
+        total_path = op.join_paths(self.root_path, path)
+        op.to_json_file(content, json_file_path=total_path)
+
+    def delete(self, path: str) -> None:
+        """
+        Delete a specific file
+        """
+        total_path = op.join_paths(self.root_path, path)
+        op.delete_file(total_path)
+
+    def exists(self, path: str) -> bool:
+        """
+        Check if a file exists
+        """
+        total_path = op.join_paths(self.root_path, path)
+        op.path_exists(total_path)
+
+    def list_contents(self, directory_path: str) -> List[dict]:
+        """
+        Return a list of files based in a directory
+        """
+        results = []
+        total_path = op.join_paths(self.root_path, path)
+        for entry_name in op.list_directories(total_path):
+            entry_abs_path = op.join_paths(total_path, entry_name)
+            if op.path_exists(entry_abs_path) or op.is_link(entry_abs_path):
+                try:
+                    results.append(entry_abs_path)
+                except FileNotFoundError:
+                    continue
+                except PermissionError:
+                    continue
+        return results
+
+
+    def create_directory(self, path: str) -> None:
+        """
+        Create a directory
+        """
+        total_path = op.join_paths(self.root_path, path)
+        op.make_dir(total_path)
+
+    def delete_directory(self, path: str) -> None:
+        """
+        Remove a directory
+        """
+        total_path = op.join_paths(self.root_path, path)
+        op.delete_dir(total_path)   

--- a/src/tractusx_sdk/industry/adapters/submodel_adapters/file_system_adapter.py
+++ b/src/tractusx_sdk/industry/adapters/submodel_adapters/file_system_adapter.py
@@ -76,17 +76,17 @@ class FileSystemAdapter(SubmodelAdapter):
         Check if a file exists
         """
         total_path = op.join_paths(self.root_path, path)
-        op.path_exists(total_path)
+        return op.path_exists(total_path)
 
     def list_contents(self, directory_path: str) -> List[dict]:
         """
         Return a list of files based in a directory
         """
         results = []
-        total_path = op.join_paths(self.root_path, path)
+        total_path = op.join_paths(self.root_path, directory_path)
         for entry_name in op.list_directories(total_path):
             entry_abs_path = op.join_paths(total_path, entry_name)
-            if op.path_exists(entry_abs_path) or op.is_link(entry_abs_path):
+            if op.is_file(entry_abs_path):
                 try:
                     results.append(entry_abs_path)
                 except FileNotFoundError:


### PR DESCRIPTION
## WHAT

This PR introduces the **Submodel Server Adapter** framework along with the first adapter implementation: `FileSystem`.

## WHY

We want to support a local Submodel implementation. Additionally, by providing an adapter-based architecture, users can easily implement and plug in their own custom adapters if needed.

## FURTHER NOTES

Closes #87 
