### PR TITLE
fix: Populate the sort_field with a valid value.

### DIFF
--- a/src/tractusx_sdk/dataspace/models/connector/model_factory.py
+++ b/src/tractusx_sdk/dataspace/models/connector/model_factory.py
@@ -344,7 +344,7 @@ class ModelFactory:
             offset: int = 0,
             limit: int = 10,
             sort_order: str = "DESC",
-            sort_field: str = "",
+            sort_field: str = "createdAt",
             filter_expression: list[dict] = None,
             **kwargs
     ):


### PR DESCRIPTION
## WHAT

Populate the `sort_field` with a valid value.

## WHY
The current value raises an error:

```json
[
  {
    "message": "optional value 'https://w3id.org/edc/v0.0.1/ns/sortField' is blank",
    "type": "ValidationFailure",
    "path": "https://w3id.org/edc/v0.0.1/ns/sortField",
    "invalidValue": null
  }
]
```

