### PR TITLE
fix: Add a default sortfield value to the queryspec model

### DIFF
--- a/src/tractusx_sdk/dataspace/models/connector/base_policy_model.py
+++ b/src/tractusx_sdk/dataspace/models/connector/base_policy_model.py
@@ -36,9 +36,9 @@ class BasePolicyModel(BaseModel, ABC):
     context: Optional[Union[dict, list, str]] = Field(default={
         "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
     })
-    permissions: Optional[list[dict]] = Field(default_factory=list)
-    prohibitions: Optional[list[dict]] = Field(default_factory=list)
-    obligations: Optional[list[dict]] = Field(default_factory=list)
+    permissions: Optional[dict | list[dict]] = Field(default_factory=list)
+    prohibitions: Optional[dict | list[dict]] = Field(default_factory=list)
+    obligations: Optional[dict | list[dict]] = Field(default_factory=list)
 
     class _Builder(BaseModel._Builder):
         def id(self, oid: str):
@@ -49,14 +49,14 @@ class BasePolicyModel(BaseModel, ABC):
             self._data["context"] = context
             return self
 
-        def permissions(self, permissions: list):
+        def permissions(self, permissions: dict | list[dict]):
             self._data["permissions"] = permissions
             return self
 
-        def prohibitions(self, prohibitions: list):
+        def prohibitions(self, prohibitions: dict | list[dict]):
             self._data["prohibitions"] = prohibitions
             return self
 
-        def obligations(self, obligations: list):
+        def obligations(self, obligations: dict | list[dict]):
             self._data["obligations"] = obligations
             return self

--- a/src/tractusx_sdk/dataspace/models/connector/base_queryspec_model.py
+++ b/src/tractusx_sdk/dataspace/models/connector/base_queryspec_model.py
@@ -36,7 +36,7 @@ class BaseQuerySpecModel(BaseModel, ABC):
     offset: Optional[int] = Field(default=0)
     limit: Optional[int] = Field(default=10)
     sort_order: Optional[str] = Field(default="DESC", pattern="^(ASC|DESC)$")
-    sort_field: Optional[str] = Field(default="")
+    sort_field: Optional[str] = Field(default="createdAt")
     filter_expression: Optional[list[dict]] = Field(default_factory=list)
 
     class _Builder(BaseModel._Builder):

--- a/src/tractusx_sdk/dataspace/models/connector/model_factory.py
+++ b/src/tractusx_sdk/dataspace/models/connector/model_factory.py
@@ -344,7 +344,7 @@ class ModelFactory:
             offset: int = 0,
             limit: int = 10,
             sort_order: str = "DESC",
-            sort_field: str = "",
+            sort_field: str = "createdAt",
             filter_expression: list[dict] = None,
             **kwargs
     ):

--- a/tests/dataspace/models/connector/test_model_factory_queryspec.py
+++ b/tests/dataspace/models/connector/test_model_factory_queryspec.py
@@ -45,7 +45,7 @@ class TestModelFactoryQuerySpec(unittest.TestCase):
         self.assertEqual(0, model.offset)
         self.assertEqual(10, model.limit)
         self.assertEqual("DESC", model.sort_order)
-        self.assertEqual("", model.sort_field)
+        self.assertEqual("createdAt", model.sort_field)
         self.assertEqual([], model.filter_expression)
         self.assertEqual({
             "@vocab": "https://w3id.org/edc/v0.0.1/ns/"


### PR DESCRIPTION
## WHAT

This PR adds a non-empty, non-null default value to the `sortField` parameter of a `QuerySpec` model

## WHY

The Connector does not accept the `sortField` being empty, when parsing a `QuerySpec`

## FURTHER NOTES

* Also fixed some bad typings regarding a Policy model's permissions, prohibitions and obligations.