### PR TITLE
feat: change Adapter.request response type

### DIFF
--- a/src/tractusx_sdk/dataspace/adapters/adapter.py
+++ b/src/tractusx_sdk/dataspace/adapters/adapter.py
@@ -171,8 +171,4 @@ class Adapter:
             **kwargs
         )
 
-        return HttpTools.json_response(
-            data=response.json(),
-            status_code=response.status_code,
-            headers=dict(response.headers)
-        )
+        return response

--- a/tests/dataspace/adapters/test_adapter.py
+++ b/tests/dataspace/adapters/test_adapter.py
@@ -57,8 +57,7 @@ class TestAdapter(unittest.TestCase):
         response = self.adapter.request("get", "test-endpoint")
 
         self.assertEqual(200, response.status_code)
-        self.assertEqual(mock_response_data, jloads(response.body.decode("utf-8")))
-        self.assertEqual("application/json", response.headers["Content-Type"])
+        self.assertEqual(mock_response_data, response.json())
 
     def tearDown(self):
         self.adapter.close()


### PR DESCRIPTION
## WHAT

This PR change the `Adapter.request` method response type from fastapi.responses.JSONResponse to requests.Response

## WHY

Please check https://github.com/eclipse-tractusx/tractusx-sdk/issues/99 for more information

## FURTHER NOTES

Closes https://github.com/eclipse-tractusx/tractusx-sdk/issues/99
