### PR TITLE
feat: implement AuthManagerInterface and update authentication handling in managers

### DIFF
--- a/src/tractusx_sdk/dataspace/managers/auth_manager.py
+++ b/src/tractusx_sdk/dataspace/managers/auth_manager.py
@@ -28,8 +28,9 @@
 ## Abstracted from the static method is_authorized
 
 from fastapi import Request
+from .auth_manager_interface import AuthManagerInterface
 
-class AuthManager:
+class AuthManager(AuthManagerInterface):
     configured_api_key: str
     api_key_header: str
     auth_enabled: bool
@@ -53,3 +54,8 @@ class AuthManager:
             return True
         
         return False
+    
+    def get_auth_headers(self) -> dict:
+        if not self.auth_enabled:
+            raise RuntimeError("Authentication is not enabled. Cannot get auth headers.")
+        return {self.api_key_header: self.configured_api_key}

--- a/src/tractusx_sdk/dataspace/managers/auth_manager_interface.py
+++ b/src/tractusx_sdk/dataspace/managers/auth_manager_interface.py
@@ -1,0 +1,37 @@
+#################################################################################
+# Tractus-X - Industry Flag Service
+#
+# Copyright (c) 2025 LKS NEXT
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+class AuthManagerInterface:
+    """
+    Interface for authentication managers in the Tractus-X SDK.
+    Implementations should provide a method to return authentication headers.
+    """
+
+    def get_auth_headers(self) -> dict:
+        """
+        Returns a dictionary of authentication headers to be included in HTTP requests.
+
+        Returns:
+            dict: A dictionary containing authentication headers.
+        """
+        raise NotImplementedError("get_headers must be implemented by subclasses")

--- a/src/tractusx_sdk/dataspace/managers/oauth2_manager.py
+++ b/src/tractusx_sdk/dataspace/managers/oauth2_manager.py
@@ -22,8 +22,9 @@
 #################################################################################
 
 from keycloak.keycloak_openid import KeycloakOpenID
+from .auth_manager_interface import AuthManagerInterface
 
-class OAuth2Manager:
+class OAuth2Manager(AuthManagerInterface):
     
     """
     Class responsible for managing the IAM IDP Service
@@ -87,3 +88,6 @@ class OAuth2Manager:
         ## Build token header
         headers["Authorization"] = "Bearer " + self.get_token()
         return headers
+    
+    def get_auth_headers(self):
+        return self.get_token()

--- a/src/tractusx_sdk/dataspace/services/connector/base_connector_service.py
+++ b/src/tractusx_sdk/dataspace/services/connector/base_connector_service.py
@@ -26,6 +26,7 @@ from ..service import BaseService
 from ...adapters.connector.adapter_factory import AdapterFactory
 from ...controllers.connector.base_dma_controller import BaseDmaController
 from ...controllers.connector.controller_factory import ControllerFactory
+from ...managers.auth_manager import AuthManagerInterface
 
 
 class BaseConnectorService(BaseService):
@@ -36,14 +37,19 @@ class BaseConnectorService(BaseService):
     def __init__(self, dataspace_version: str, base_url: str, dma_path: str,
                  consumer_service: BaseConnectorConsumerService,
                  provider_service: BaseConnectorProviderService,
-                 headers: dict = None):
+                 headers: dict = None,
+                 auth_header: AuthManagerInterface | None = None):
         self.dataspace_version = dataspace_version
+
+        merged_headers = headers or {}
+        if auth_header is not None:
+            merged_headers.update(auth_header.get_auth_headers())
 
         dma_adapter = AdapterFactory.get_dma_adapter(
             dataspace_version=dataspace_version,
             base_url=base_url,
             dma_path=dma_path,
-            headers=headers
+            headers=merged_headers
         )
 
         self._contract_agreement_controller = ControllerFactory.get_contract_agreement_controller(


### PR DESCRIPTION
## WHAT

This PR introduces a unified authentication manager interface for the SDK. It adds two implementations: `AuthManager` for API Key-based authentication and `OAuth2Manager` for OAuth2-based authentication. The ConnectorService now accepts an `auth_header` parameter, which is used internally to retrieve authentication headers via `auth_header.get_auth_headers()`.

## WHY

This change simplifies the authentication mechanism in the SDK, making it easier and more flexible for users to configure authentication using either an API Key or OAuth2. It improves usability and maintainability by encapsulating authentication logic in dedicated manager classes.

## FURTHER NOTES


Closes #112 
