### PR TITLE
bugfix: add configurable prefix and resolved protected keys [`id` & `type`] issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Further information can be found on the [README.md](README.md) file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.8]
+
+### Fixed
+
+- bugfix: add configurable prefix and resolved protected keys [`id` & `type`] issue by @matbmoser in https://github.com/eclipse-tractusx/tractusx-sdk/pull/140
 
 ## [0.3.7]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "tractusx_sdk"
-version = "0.3.7"
+version = "0.3.8"
 description = "Eclipse Tractus-X Software Development KIT - The Dataspace & Industry Foundation Middleware"
 license = { text = "Apache-2.0" }
 readme = "README.md"

--- a/src/tractusx_sdk/__init__.py
+++ b/src/tractusx_sdk/__init__.py
@@ -19,6 +19,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #################################################################################
-__version__ = '0.3.7'
+__version__ = '0.3.8'
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"

--- a/src/tractusx_sdk/dataspace/__init__.py
+++ b/src/tractusx_sdk/dataspace/__init__.py
@@ -21,6 +21,6 @@
 #################################################################################
 
 # Package-level variables
-__version__ = '0.3.7'
+__version__ = '0.3.8'
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"

--- a/src/tractusx_sdk/dataspace/services/connector/base_connector_consumer.py
+++ b/src/tractusx_sdk/dataspace/services/connector/base_connector_consumer.py
@@ -577,6 +577,37 @@ class BaseConnectorConsumerService(BaseService):
         dct_type_key="'http://purl.org/dc/terms/type'.'@id'",
         operator="="
     ) -> tuple[str, str]:
+        """
+        Performs DSP (Dataspace Protocol) exchange filtered by DCT (Dublin Core Terms) type from the DCMI Metadata Terms.
+        
+        This method establishes an EDC connection by filtering the catalog based on a specific DCT type,
+        negotiates the contract, and returns the dataplane endpoint and access token for data access.
+
+        Parameters:
+        counter_party_id (str): The identifier of the counterparty (Business Partner Number [BPN]).
+        counter_party_address (str): The URL of the EDC provider's DSP endpoint.
+        dct_type (str): The DCT type to filter assets by (e.g., "IndustryFlagService").
+        policies (list, optional): List of allowed policies for contract negotiation. Defaults to None.
+        dct_type_key (str, optional): The JSON path key for DCT type filtering. 
+            Defaults to "'http://purl.org/dc/terms/type'.'@id'".
+        operator (str, optional): The comparison operator for filtering. Defaults to "=".
+
+        Returns:
+        tuple[str, str]: A tuple containing (dataplane_endpoint, access_token) for data access.
+
+        Raises:
+        RuntimeError: If EDR negotiation fails or dataplane details cannot be retrieved.
+        ConnectionError: If catalog retrieval fails.
+        
+        Example:
+        ```python
+        endpoint, token = connector.do_dsp_by_dct_type(
+            counter_party_id="BPNL000000000001",
+            counter_party_address="https://provider-edc.example.com/api/v1/dsp",
+            dct_type="IndustryFlagService"
+        )
+        ```
+        """
         return self.do_dsp(
             counter_party_id=counter_party_id,
             counter_party_address=counter_party_address,
@@ -595,6 +626,37 @@ class BaseConnectorConsumerService(BaseService):
         asset_id_key="https://w3id.org/edc/v0.0.1/ns/id",
         operator="="
     ) -> tuple[str, str]:
+        """
+        Performs DSP (Dataspace Protocol) exchange filtered by specific asset ID.
+        
+        This method establishes an EDC connection by filtering the catalog for a specific asset,
+        negotiates the contract, and returns the dataplane endpoint and access token for data access.
+
+        Parameters:
+        counter_party_id (str): The identifier of the counterparty (Business Partner Number [BPN]).
+        counter_party_address (str): The URL of the EDC provider's DSP endpoint.
+        asset_id (str): The unique identifier of the asset to access.
+        policies (list, optional): List of allowed policies for contract negotiation. Defaults to None.
+        asset_id_key (str, optional): The JSON path key for asset ID filtering. 
+            Defaults to "https://w3id.org/edc/v0.0.1/ns/id".
+        operator (str, optional): The comparison operator for filtering. Defaults to "=".
+
+        Returns:
+        tuple[str, str]: A tuple containing (dataplane_endpoint, access_token) for data access.
+
+        Raises:
+        RuntimeError: If EDR negotiation fails or dataplane details cannot be retrieved.
+        ConnectionError: If catalog retrieval fails.
+        
+        Example:
+        ```python
+        endpoint, token = connector.do_dsp_by_asset_id(
+            counter_party_id="BPNL000000000001",
+            counter_party_address="https://provider-edc.example.com/api/v1/dsp",
+            asset_id="urn:uuid:12345678-1234-1234-1234-123456789abc"
+        )
+        ```
+        """
         return self.do_dsp(
             counter_party_id=counter_party_id,
             counter_party_address=counter_party_address,
@@ -615,6 +677,43 @@ class BaseConnectorConsumerService(BaseService):
         session=None,
         **kwargs,
     ):
+        """
+        Executes an HTTP GET request to an asset behind an EDC, filtered by DCT type.
+        
+        This method performs the complete DSP exchange (catalog retrieval, contract negotiation,
+        and EDR token acquisition) and then executes a GET request to the resulting dataplane endpoint.
+
+        Parameters:
+        counter_party_id (str): The identifier of the counterparty (Business Partner Number [BPN]).
+        counter_party_address (str): The URL of the EDC provider's DSP endpoint.
+        dct_type (str): The DCT type to filter assets by (e.g., "IndustryFlagService").
+        policies (list, optional): List of allowed policies for contract negotiation. Defaults to None.
+        dct_type_key (str, optional): The JSON path key for DCT type filtering. 
+            Defaults to "'http://purl.org/dc/terms/type'.'@id'".
+        operator (str, optional): The comparison operator for filtering. Defaults to "=".
+        session (requests.Session, optional): HTTP session for connection reuse. Defaults to None.
+        **kwargs: Additional keyword arguments passed to the underlying do_get method 
+            (e.g., path, headers, timeout, verify, params, allow_redirects).
+
+        Returns:
+        requests.Response: The HTTP response from the GET request to the dataplane.
+
+        Raises:
+        RuntimeError: If EDR negotiation fails or dataplane details cannot be retrieved.
+        ConnectionError: If catalog retrieval or HTTP request fails.
+        
+        Example:
+        ```python
+        response = connector.do_get_by_dct_type(
+            counter_party_id="BPNL000000000001",
+            counter_party_address="https://provider-edc.example.com/api/v1/dsp",
+            dct_type="IndustryFlagService",
+            path="/data/latest",
+            timeout=30
+        )
+        data = response.json()
+        ```
+        """
         return self.do_get(
             counter_party_id=counter_party_id,
             counter_party_address=counter_party_address,
@@ -637,6 +736,44 @@ class BaseConnectorConsumerService(BaseService):
         session=None,
         **kwargs,
     ):
+        """
+        Executes an HTTP GET request to a specific asset behind an EDC.
+        
+        This method performs the complete DSP exchange (catalog retrieval, contract negotiation,
+        and EDR token acquisition) for a specific asset and then executes a GET request to the 
+        resulting dataplane endpoint.
+
+        Parameters:
+        counter_party_id (str): The identifier of the counterparty (Business Partner Number [BPN]).
+        counter_party_address (str): The URL of the EDC provider's DSP endpoint.
+        asset_id (str): The unique identifier of the asset to access.
+        policies (list, optional): List of allowed policies for contract negotiation. Defaults to None.
+        asset_id_key (str, optional): The JSON path key for asset ID filtering. 
+            Defaults to "https://w3id.org/edc/v0.0.1/ns/id".
+        operator (str, optional): The comparison operator for filtering. Defaults to "=".
+        session (requests.Session, optional): HTTP session for connection reuse. Defaults to None.
+        **kwargs: Additional keyword arguments passed to the underlying do_get method 
+            (e.g., path, headers, timeout, verify, params, allow_redirects).
+
+        Returns:
+        requests.Response: The HTTP response from the GET request to the dataplane.
+
+        Raises:
+        RuntimeError: If EDR negotiation fails or dataplane details cannot be retrieved.
+        ConnectionError: If catalog retrieval or HTTP request fails.
+        
+        Example:
+        ```python
+        response = connector.do_get_by_asset_id(
+            counter_party_id="BPNL000000000001",
+            counter_party_address="https://provider-edc.example.com/api/v1/dsp",
+            asset_id="urn:uuid:12345678-1234-1234-1234-123456789abc",
+            path="/data/latest",
+            headers={"Accept": "application/json"}
+        )
+        data = response.json()
+        ```
+        """
         return self.do_get(
             counter_party_id=counter_party_id,
             counter_party_address=counter_party_address,
@@ -660,6 +797,46 @@ class BaseConnectorConsumerService(BaseService):
         session=None,
         **kwargs,
     ) -> tuple[str, str]:
+        """
+        Executes an HTTP POST request to an asset behind an EDC, filtered by DCT type.
+        
+        This method performs the complete DSP exchange (catalog retrieval, contract negotiation,
+        and EDR token acquisition) and then executes a POST request with the provided body to 
+        the resulting dataplane endpoint.
+
+        Parameters:
+        counter_party_id (str): The identifier of the counterparty (Business Partner Number [BPN]).
+        counter_party_address (str): The URL of the EDC provider's DSP endpoint.
+        body: The request body to send in the POST request. Can be dict, list, or any JSON-serializable object.
+        dct_type (str): The DCT type to filter assets by (e.g., "IndustryFlagService").
+        policies (list, optional): List of allowed policies for contract negotiation. Defaults to None.
+        dct_type_key (str, optional): The JSON path key for DCT type filtering. 
+            Defaults to "'http://purl.org/dc/terms/type'.'@id'".
+        operator (str, optional): The comparison operator for filtering. Defaults to "=".
+        session (requests.Session, optional): HTTP session for connection reuse. Defaults to None.
+        **kwargs: Additional keyword arguments passed to the underlying do_post method 
+            (e.g., path, content_type, headers, timeout, verify, allow_redirects).
+
+        Returns:
+        tuple[str, str]: A tuple containing (dataplane_endpoint, access_token) for the completed request.
+
+        Raises:
+        RuntimeError: If EDR negotiation fails or dataplane details cannot be retrieved.
+        ConnectionError: If catalog retrieval or HTTP request fails.
+        
+        Example:
+        ```python
+        request_data = {"query": "SELECT * FROM data", "limit": 100}
+        endpoint, token = connector.do_post_by_dct_type(
+            counter_party_id="BPNL000000000001",
+            counter_party_address="https://provider-edc.example.com/api/v1/dsp",
+            body=request_data,
+            dct_type="QueryService",
+            path="/query",
+            content_type="application/json"
+        )
+        ```
+        """
         return self.do_post(
             counter_party_id=counter_party_id,
             counter_party_address=counter_party_address,
@@ -684,6 +861,46 @@ class BaseConnectorConsumerService(BaseService):
         session=None,
         **kwargs
     ) -> tuple[str, str]:
+        """
+        Executes an HTTP POST request to a specific asset behind an EDC.
+        
+        This method performs the complete DSP exchange (catalog retrieval, contract negotiation,
+        and EDR token acquisition) for a specific asset and then executes a POST request with 
+        the provided body to the resulting dataplane endpoint.
+
+        Parameters:
+        counter_party_id (str): The identifier of the counterparty (Business Partner Number [BPN]).
+        counter_party_address (str): The URL of the EDC provider's DSP endpoint.
+        body: The request body to send in the POST request. Can be dict, list, or any JSON-serializable object.
+        asset_id (str): The unique identifier of the asset to access.
+        policies (list, optional): List of allowed policies for contract negotiation. Defaults to None.
+        asset_id_key (str, optional): The JSON path key for asset ID filtering. 
+            Defaults to "https://w3id.org/edc/v0.0.1/ns/id".
+        operator (str, optional): The comparison operator for filtering. Defaults to "=".
+        session (requests.Session, optional): HTTP session for connection reuse. Defaults to None.
+        **kwargs: Additional keyword arguments passed to the underlying do_post method 
+            (e.g., path, content_type, headers, timeout, verify, allow_redirects).
+
+        Returns:
+        tuple[str, str]: A tuple containing (dataplane_endpoint, access_token) for the completed request.
+
+        Raises:
+        RuntimeError: If EDR negotiation fails or dataplane details cannot be retrieved.
+        ConnectionError: If catalog retrieval or HTTP request fails.
+        
+        Example:
+        ```python
+        update_data = {"status": "processed", "timestamp": "2025-08-07T10:30:00Z"}
+        endpoint, token = connector.do_post_by_asset_id(
+            counter_party_id="BPNL000000000001",
+            counter_party_address="https://provider-edc.example.com/api/v1/dsp",
+            body=update_data,
+            asset_id="urn:uuid:12345678-1234-1234-1234-123456789abc",
+            path="/update",
+            content_type="application/json"
+        )
+        ```
+        """
         return self.do_post(
             counter_party_id=counter_party_id,
             counter_party_address=counter_party_address,

--- a/src/tractusx_sdk/industry/__init__.py
+++ b/src/tractusx_sdk/industry/__init__.py
@@ -21,6 +21,6 @@
 #################################################################################
 
 # Package-level variables
-__version__ = '0.3.7'
+__version__ = '0.3.8'
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"

--- a/tests/extensions/semantics/test_schema_to_context_translator.py
+++ b/tests/extensions/semantics/test_schema_to_context_translator.py
@@ -189,7 +189,7 @@ class TestSchemaToJsonLD:
         assert "schema" in context
         assert context["schema"] == "https://schema.org/"
         assert "TestAspect" in context
-        assert context["testaspect-aspect"] == "urn:samm:example:1.0.0#"
+        assert context["cx"] == "urn:samm:example:1.0.0#"
         assert "@definition" in context
         assert context["@definition"] == "Test string property"
 
@@ -202,7 +202,7 @@ class TestSchemaToJsonLD:
         
         context = result["@context"]
         assert "Custom" in context
-        assert context["Custom"]["@id"] == "custom-aspect:Custom"
+        assert context["Custom"]["@id"] == "cx:Custom"
 
     def test_schema_to_jsonld_invalid_semantic_id(self, translator):
         """Test with invalid semantic ID."""
@@ -230,9 +230,144 @@ class TestSchemaToJsonLD:
         context = result["@context"]
         
         assert "TestAspect" in context
-        assert context["testaspect-aspect"] == "urn:samm:example:1.0.0#"
+        assert context["cx"] == "urn:samm:example:1.0.0#"
         assert "@definition" in context
         assert context["@definition"] == "Test description"
+
+    def test_schema_to_jsonld_with_conflicting_properties(self, translator):
+        """Test schema with properties that conflict with JSON-LD reserved words."""
+        semantic_id = "urn:samm:example:1.0.0#TestAspect"
+        
+        # Create a schema with property references that would create "id" and "type" context entries
+        schema = {
+            "type": "object",
+            "description": "Schema with conflicting properties",
+            "properties": {
+                "identifier": {
+                    "$ref": "#/components/schemas/IdProperty"
+                },
+                "typeField": {
+                    "$ref": "#/components/schemas/TypeProperty"
+                },
+                "normalProp": {
+                    "$ref": "#/components/schemas/StringProperty"
+                }
+            },
+            "components": {
+                "schemas": {
+                    "IdProperty": {
+                        "type": "string",
+                        "description": "An ID property"
+                    },
+                    "TypeProperty": {
+                        "type": "string", 
+                        "description": "A type property"
+                    },
+                    "StringProperty": {
+                        "type": "string",
+                        "description": "A normal property"
+                    }
+                }
+            }
+        }
+        
+        result = translator.schema_to_jsonld(semantic_id, schema)
+        context = result["@context"]
+        
+        # Verify basic structure
+        assert "TestAspect" in context
+        assert context["cx"] == "urn:samm:example:1.0.0#"
+        assert "@definition" in context
+        assert context["@definition"] == "Schema with conflicting properties"
+        
+        # Verify properties are present (these should be normal properties, not conflicting ones)
+        assert "identifier" in context
+        assert "typeField" in context
+        assert "normalProp" in context
+        
+        # Verify the standard JSON-LD properties remain unchanged
+        assert context["id"] == "@id"
+        assert context["type"] == "@type"
+
+    @patch.object(SammSchemaContextTranslator, 'create_node')
+    def test_schema_to_jsonld_with_id_type_conflict_resolution(self, mock_create_node, translator):
+        """Test the specific logic for handling 'id' and 'type' property conflicts."""
+        semantic_id = "urn:samm:example:1.0.0#TestAspect"
+        schema = {"type": "object", "description": "Test schema"}
+        
+        # Mock create_node to return a context that has "id" and "type" as non-string values
+        # This simulates the scenario where the nested context would conflict with JSON-LD reserved words
+        mock_create_node.return_value = {
+            "@context": {
+                "@version": 1.1,
+                "id": {"@id": "aspect:id", "@type": "schema:string"},  # Non-string value that should get prefixed
+                "type": {"@id": "aspect:type", "@type": "schema:string"},  # Non-string value that should get prefixed
+                "normalProp": {"@id": "aspect:normalProp", "@type": "schema:string"},
+                "stringValue": "this-stays-as-is"  # String value that should not get prefixed
+            }
+        }
+        
+        result = translator.schema_to_jsonld(semantic_id, schema)
+        context = result["@context"]
+        
+        # Verify that non-string "id" and "type" properties get prefixed with aspect prefix
+        assert "cx:id" in context
+        assert "cx:type" in context
+        assert context["cx:id"] == {"@id": "aspect:id", "@type": "schema:string"}
+        assert context["cx:type"] == {"@id": "aspect:type", "@type": "schema:string"}
+        
+        # Verify that normal properties don't get prefixed
+        assert "normalProp" in context
+        assert context["normalProp"] == {"@id": "aspect:normalProp", "@type": "schema:string"}
+        
+        # Verify that string values don't get prefixed (even if they're named "id" or "type")
+        assert "stringValue" in context
+        assert context["stringValue"] == "this-stays-as-is"
+        
+        # Verify that the conflicting properties are NOT present as standard JSON-LD properties
+        # because they were moved to prefixed versions
+        assert "id" not in context
+        assert "type" not in context
+        
+        # Verify other standard context elements are present
+        assert context["@version"] == 1.1
+        assert context["cx"] == "urn:samm:example:1.0.0#"
+        assert context["@definition"] == "Test schema"
+
+    @patch.object(SammSchemaContextTranslator, 'create_node')
+    def test_schema_to_jsonld_without_id_type_conflicts(self, mock_create_node, translator):
+        """Test that standard JSON-LD properties are preserved when there are no conflicts."""
+        semantic_id = "urn:samm:example:1.0.0#TestAspect"
+        schema = {"type": "object", "description": "Test schema"}
+        
+        # Mock create_node to return a context with standard JSON-LD id/type as strings
+        # (these should not be prefixed since they are strings)
+        mock_create_node.return_value = {
+            "@context": {
+                "@version": 1.1,
+                "id": "@id",  # String value - should not get prefixed
+                "type": "@type",  # String value - should not get prefixed
+                "normalProp": {"@id": "aspect:normalProp", "@type": "schema:string"},
+                "anotherProp": {"@id": "aspect:anotherProp", "@type": "schema:string"}
+            }
+        }
+        
+        result = translator.schema_to_jsonld(semantic_id, schema)
+        context = result["@context"]
+        
+        # Verify that standard JSON-LD properties are present when they are strings
+        assert "id" in context
+        assert "type" in context
+        assert context["id"] == "@id"
+        assert context["type"] == "@type"
+        
+        # Verify that conflicting prefixed versions are NOT present
+        assert "cx:id" not in context
+        assert "cx:type" not in context
+        
+        # Verify normal properties are present
+        assert "normalProp" in context
+        assert "anotherProp" in context
 
 
 class TestCreateNode:
@@ -895,7 +1030,7 @@ class TestIntegration:
         assert "@context" in result
         context = result["@context"]
         assert "ComplexAspect" in context
-        assert context["complexaspect-aspect"] == "urn:samm:example:1.0.0#"
+        assert context["cx"] == "urn:samm:example:1.0.0#"
         assert "@definition" in context
         assert context["@definition"] == "Complex nested schema"
 

--- a/tests/extensions/semantics/test_schema_to_context_translator.py
+++ b/tests/extensions/semantics/test_schema_to_context_translator.py
@@ -330,7 +330,7 @@ class TestSchemaToJsonLD:
         assert "type" not in context
         
         # Verify other standard context elements are present
-        assert context["@version"] == 1.1
+        assert math.isclose(context["@version"], 1.1, rel_tol=1e-09, abs_tol=1e-09)
         assert context["cx"] == "urn:samm:example:1.0.0#"
         assert context["@definition"] == "Test schema"
 


### PR DESCRIPTION
## WHAT

- Fixed conflict with jsonld protected keys which couldnt be overrided

## WHY

Introduce a configurable aspect prefix for schema preparation and JSON-LD conversion, addressing the problem of protected keys in the process.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
