### PR TITLE
fix: change logger level from info to debug for transfer_id cache logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 -fix: update parameters for POST request in BaseConnectorConsumerService to include json and body options by @CDiezRodriguez in https://github.com/eclipse-tractusx/tractusx-sdk/pull/149
 -fix: refactor get_catalogs_by_dct_type and get_catalogs_with_filter to use filter_expression by @CDiezRodriguez in https://github.com/eclipse-tractusx/tractusx-sdk/pull/148
+-fix: change logger level from info to debug for transfer_id cache logging by @CDiezRodriguez in https://github.com/eclipse-tractusx/tractusx-sdk/pull/151
 
 ## [0.4.1]
 

--- a/src/tractusx_sdk/dataspace/services/connector/base_connector_consumer.py
+++ b/src/tractusx_sdk/dataspace/services/connector/base_connector_consumer.py
@@ -538,7 +538,7 @@ class BaseConnectorConsumerService(BaseService):
         ## If is there return the cached one, if the selection is the same the transfer id can be reused!
         if (transfer_process_id is not None):
             if self.logger:
-                self.logger.info(
+                self.logger.debug(
                     "[EDC Service] [%s]: EDR transfer_id=[%s] found in the cache for counter_party_id=[%s], filter=[%s] and selected policies",
                     counter_party_address, transfer_process_id, counter_party_id, filter_expression)
             return transfer_process_id


### PR DESCRIPTION
## WHAT

This pull request makes a minor logging change to the `get_transfer_id` method in `base_connector_consumer.py`. The log level for cached transfer ID lookups has been changed from `info` to `debug`, which will reduce unnecessary log noise in production environments.

## WHY

Previously, both successful and error outcomes were logged at the same level, making it difficult to distinguish normal execution from actual errors. This change improves log clarity and allows easier monitoring and troubleshooting.

## FURTHER NOTES

Closes #150
