### PR TITLE
fix: Refactor HTTP GET calls to use session method

### DIFF
--- a/src/tractusx_sdk/industry/services/aas_service.py
+++ b/src/tractusx_sdk/industry/services/aas_service.py
@@ -157,7 +157,7 @@ class AasService:
 
         # Make the request
         url = f"{self.aas_url}/shell-descriptors"
-        response = HttpTools.do_get(
+        response = HttpTools.do_get_with_session(
             url=url,
             params=params,
             headers=headers,
@@ -357,7 +357,7 @@ class AasService:
 
         # Make the request
         url = f"{self.aas_url}/shell-descriptors/{encoded_identifier}/submodel-descriptors"
-        response = HttpTools.do_get(
+        response = HttpTools.do_get_with_session(
             url=url,
             params=params,
             headers=headers,


### PR DESCRIPTION
## WHAT

Raised in this PR #144 there is an issue with the do_get which was not fixed.

## WHY

The correct function is do_get_with_session which can accept the session as param.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
