### PR TITLE
feat: add do_get/put_by_dct_type_with_bpnl convenience methods to connector consumer service

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -21,6 +21,6 @@
 #################################################################################
 
 # tractusx_sdk Package-level variables
-__version__ = '0.7.1'
+__version__ = '0.8.0-rc1'
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"

--- a/docs/api-reference/dataspace-library/connector/services.md
+++ b/docs/api-reference/dataspace-library/connector/services.md
@@ -339,6 +339,7 @@ These methods wrap the full catalog → negotiate → transfer → HTTP request 
 | `do_get(counter_party_id, counter_party_address, filter_expression, ...)` | `filter_expression: list[dict]` | Full DSP flow + GET data from the data plane |
 | `do_get_with_bpnl(bpnl, counter_party_address, filter_expression, ...)` ⭐ | `bpnl: str` | Same with BPNL resolution — **Saturn only** |
 | `do_get_by_dct_type(counter_party_id, counter_party_address, dct_type, ...)` | `dct_type: str` | GET flow filtered by `dct:type` |
+| `do_get_by_dct_type_with_bpnl(bpnl, counter_party_address, dct_type, ...)` ⭐ | `bpnl: str`, `dct_type: str` | Same with BPNL resolution — **Saturn only** |
 | `do_get_by_asset_id(counter_party_id, counter_party_address, asset_id, ...)` | `asset_id: str` | GET flow filtered by asset ID |
 | `do_post(counter_party_id, counter_party_address, filter_expression, json, ...)` | `json: dict` | Full DSP flow + POST payload to the data plane |
 | `do_post_with_bpnl(bpnl, counter_party_address, filter_expression, json, ...)` ⭐ | `bpnl: str`, `json: dict` | Same with BPNL resolution — **Saturn only** |
@@ -346,6 +347,7 @@ These methods wrap the full catalog → negotiate → transfer → HTTP request 
 | `do_post_by_asset_id(counter_party_id, counter_party_address, asset_id, json, ...)` | `asset_id: str` | POST flow filtered by asset ID |
 | `do_put(counter_party_id, counter_party_address, filter_expression, json, ...)` | `json: dict` | Full DSP flow + PUT payload to the data plane |
 | `do_put_with_bpnl(bpnl, counter_party_address, filter_expression, json, ...)` ⭐ | `bpnl: str`, `json: dict` | Same with BPNL resolution — **Saturn only** |
+| `do_put_by_dct_type_with_bpnl(bpnl, counter_party_address, dct_type, json, ...)` ⭐ | `bpnl: str`, `dct_type: str`, `json: dict` | PUT flow filtered by `dct:type` with BPNL resolution — **Saturn only** |
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,7 +157,7 @@ You manage data catalogs, build data pipelines, or implement governance policies
 !!! tip "New to dataspaces?"
     Check out the [Getting Started Guide](tutorials/getting-started.md) - it takes about 10 minutes and shows you how the whole thing works.
 
-!!! info "Current release: 0.7.1"
+!!! info "Current release: 0.8.0-rc1"
     Requires Python 3.12+  
     License: Apache 2.0 (code) / CC-BY-4.0 (docs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "tractusx_sdk"
-version = "0.7.1"
+version = "0.8.0-rc1"
 description = "Eclipse Tractus-X Software Development KIT - The Dataspace & Industry Foundation Middleware"
 license = { text = "Apache-2.0" }
 readme = "README.md"

--- a/src/tractusx_sdk/__init__.py
+++ b/src/tractusx_sdk/__init__.py
@@ -20,6 +20,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #################################################################################
 
-__version__ = '0.7.1'
+__version__ = '0.8.0-rc1'
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"

--- a/src/tractusx_sdk/dataspace/__init__.py
+++ b/src/tractusx_sdk/dataspace/__init__.py
@@ -21,6 +21,6 @@
 #################################################################################
 
 # Package-level variables
-__version__ = '0.7.1'
+__version__ = '0.8.0-rc1'
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"

--- a/src/tractusx_sdk/dataspace/services/connector/saturn/connector_consumer_service.py
+++ b/src/tractusx_sdk/dataspace/services/connector/saturn/connector_consumer_service.py
@@ -1174,6 +1174,121 @@ class ConnectorConsumerService(BaseConnectorConsumerService):
             timeout=timeout, allow_redirects=allow_redirects, session=session
         )
         
+
+    def do_get_by_dct_type_with_bpnl(
+        self,
+        bpnl: str,
+        counter_party_address: str,
+        dct_type: str,
+        policies: list = None,
+        dct_type_key=DEFAULT_DCT_TYPE_KEY,
+        operator="=",
+        session=None,
+        **kwargs,
+    ):
+        """
+        Executes an HTTP GET request to an asset behind an EDC, filtered by DCT type.
+
+        Uses the BPNL to resolve the counterparty identity and the correct DSP
+        endpoint (including Saturn's ``/2025-1`` version suffix) via the consumer
+        EDC's ``/v4alpha/connectordiscovery/dspversionparams`` endpoint, instead
+        of relying on a pre-resolved ``counter_party_address``.
+
+        Parameters:
+        bpnl (str): The Business Partner Number (BPN) of the counterparty.
+        counter_party_address (str): Base DSP URL hint (e.g. from BDRS). The
+            consumer EDC resolves the final Saturn-aware endpoint from this.
+        dct_type (str): The DCT type to filter assets by (e.g., "PcfExchange").
+        policies (list, optional): List of allowed policies for contract
+            negotiation. Defaults to None.
+        dct_type_key (str, optional): The JSON path key for DCT type filtering.
+            Defaults to "'http://purl.org/dc/terms/type'.'@id'".
+        operator (str, optional): The comparison operator for filtering.
+            Defaults to "=".
+        session (requests.Session, optional): HTTP session for connection reuse.
+            Defaults to None.
+        **kwargs: Additional keyword arguments passed to the underlying
+            ``do_get_with_bpnl`` method (e.g., path, headers, timeout, verify,
+            params, allow_redirects).
+
+        Returns:
+        requests.Response: The HTTP response from the GET request to the dataplane.
+
+        Raises:
+        RuntimeError: If EDR negotiation fails or dataplane details cannot be retrieved.
+        ConnectionError: If catalog retrieval or HTTP request fails.
+        """
+        return self.do_get_with_bpnl(
+            bpnl=bpnl,
+            counter_party_address=counter_party_address,
+            filter_expression=[
+                self.get_filter_expression(key=dct_type_key, value=dct_type, operator=operator)
+            ],
+            policies=policies,
+            session=session,
+            **kwargs,
+        )
+
+    def do_put_by_dct_type_with_bpnl(
+        self,
+        bpnl: str,
+        counter_party_address: str,
+        dct_type: str,
+        json=None,
+        data=None,
+        policies: list = None,
+        dct_type_key=DEFAULT_DCT_TYPE_KEY,
+        operator="=",
+        session=None,
+        **kwargs,
+    ):
+        """
+        Performs an HTTP PUT request to an asset behind an EDC, filtered by DCT type.
+
+        Uses the BPNL to resolve the counterparty identity and the correct DSP
+        endpoint (including Saturn's ``/2025-1`` version suffix) via the consumer
+        EDC's ``/v4alpha/connectordiscovery/dspversionparams`` endpoint, instead
+        of relying on a pre-resolved ``counter_party_address``.
+
+        Parameters:
+        bpnl (str): The Business Partner Number (BPN) of the counterparty.
+        counter_party_address (str): Base DSP URL hint (e.g. from BDRS). The
+            consumer EDC resolves the final Saturn-aware endpoint from this.
+        dct_type (str): The DCT type to filter assets by (e.g., "PcfExchange").
+        json (dict, optional): JSON payload for the PUT request. Defaults to None.
+        data (dict, optional): Form data for the PUT request. Defaults to None.
+        policies (list, optional): List of allowed policies for contract
+            negotiation. Defaults to None.
+        dct_type_key (str, optional): The JSON path key for DCT type filtering.
+            Defaults to "'http://purl.org/dc/terms/type'.'@id'".
+        operator (str, optional): The comparison operator for filtering.
+            Defaults to "=".
+        session (requests.Session, optional): HTTP session for connection reuse.
+            Defaults to None.
+        **kwargs: Additional keyword arguments passed to the underlying
+            ``do_put_with_bpnl`` method (e.g., path, headers, timeout, verify,
+            allow_redirects).
+
+        Returns:
+        requests.Response: The HTTP response from the PUT request to the dataplane.
+
+        Raises:
+        RuntimeError: If EDR negotiation fails or dataplane details cannot be retrieved.
+        ConnectionError: If catalog retrieval or HTTP request fails.
+        """
+        return self.do_put_with_bpnl(
+            bpnl=bpnl,
+            counter_party_address=counter_party_address,
+            filter_expression=[
+                self.get_filter_expression(key=dct_type_key, value=dct_type, operator=operator)
+            ],
+            json=json,
+            data=data,
+            policies=policies,
+            session=session,
+            **kwargs,
+        )
+
     def do_put(
         self,
         counter_party_id: str,

--- a/src/tractusx_sdk/extensions/__init__.py
+++ b/src/tractusx_sdk/extensions/__init__.py
@@ -29,6 +29,6 @@ This module contains extensions for the Tractus-X SDK, including:
 - tck: Tools, Checkers, and Helpers for various SDK components
 """
 
-__version__ = '0.7.1'
+__version__ = '0.8.0-rc1'
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"

--- a/src/tractusx_sdk/industry/__init__.py
+++ b/src/tractusx_sdk/industry/__init__.py
@@ -21,7 +21,7 @@
 #################################################################################
 
 # Package-level variables
-__version__ = '0.7.1'
+__version__ = '0.8.0-rc1'
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"
 

--- a/tests/dataspace/services/connector/saturn/test_connector_consumer_service.py
+++ b/tests/dataspace/services/connector/saturn/test_connector_consumer_service.py
@@ -1017,5 +1017,206 @@ class TestSaturnConnectorConsumerService(TestCase):
 
 
 
+    def test_do_get_by_dct_type_with_bpnl_success(self):
+        """Test do_get_by_dct_type_with_bpnl delegates to do_get_with_bpnl with the correct filter expression."""
+        bpnl = "BPNL000000000001"
+        counter_party_address = "https://provider.example.com/api/v1/dsp"
+        dct_type = "https://w3id.org/catenax/taxonomy#PcfExchange"
+        policies = [{"@id": "policy-123"}]
+        path = "/pcf"
+        mock_response = mock.Mock(spec=Response)
+
+        with mock.patch.object(self.service, 'do_get_with_bpnl') as mock_do_get:
+            mock_do_get.return_value = mock_response
+
+            result = self.service.do_get_by_dct_type_with_bpnl(
+                bpnl=bpnl,
+                counter_party_address=counter_party_address,
+                dct_type=dct_type,
+                policies=policies,
+                path=path,
+            )
+
+            self.assertEqual(result, mock_response)
+            mock_do_get.assert_called_once()
+            call_kwargs = mock_do_get.call_args[1]
+            self.assertEqual(call_kwargs["bpnl"], bpnl)
+            self.assertEqual(call_kwargs["counter_party_address"], counter_party_address)
+            self.assertEqual(call_kwargs["policies"], policies)
+            self.assertEqual(call_kwargs["path"], path)
+            # Verify filter expression targets the dct_type value
+            filter_expr = call_kwargs["filter_expression"]
+            self.assertEqual(len(filter_expr), 1)
+            self.assertIn(dct_type, str(filter_expr[0]))
+
+    def test_do_get_by_dct_type_with_bpnl_uses_bpnl_for_discovery(self):
+        """Test that do_get_by_dct_type_with_bpnl triggers BPNL-based discovery (Saturn-aware URL resolution)."""
+        bpnl = "BPNL000000000001"
+        counter_party_address = "https://provider.example.com/api/v1/dsp"
+        dct_type = "https://w3id.org/catenax/taxonomy#PcfExchange"
+        dataplane_url = "https://dataplane.example.com"
+        access_token = "token-abc"
+        mock_response = mock.Mock(spec=Response)
+
+        with mock.patch.object(self.service, 'do_dsp_with_bpnl') as mock_dsp, \
+             mock.patch.object(self.service, '_execute_http_request') as mock_execute:
+            mock_dsp.return_value = (dataplane_url, access_token)
+            mock_execute.return_value = mock_response
+
+            result = self.service.do_get_by_dct_type_with_bpnl(
+                bpnl=bpnl,
+                counter_party_address=counter_party_address,
+                dct_type=dct_type,
+            )
+
+            self.assertEqual(result, mock_response)
+            # do_dsp_with_bpnl must be called (not do_dsp), ensuring Saturn discovery endpoint is used
+            mock_dsp.assert_called_once()
+            dsp_kwargs = mock_dsp.call_args[1]
+            self.assertEqual(dsp_kwargs["bpnl"], bpnl)
+            self.assertEqual(dsp_kwargs["counter_party_address"], counter_party_address)
+
+    def test_do_get_by_dct_type_with_bpnl_missing_dataplane(self):
+        """Test do_get_by_dct_type_with_bpnl raises RuntimeError when DSP returns no dataplane info."""
+        bpnl = "BPNL000000000001"
+        counter_party_address = "https://provider.example.com/api/v1/dsp"
+        dct_type = "https://w3id.org/catenax/taxonomy#PcfExchange"
+
+        with mock.patch.object(self.service, 'do_dsp_with_bpnl') as mock_dsp:
+            mock_dsp.return_value = (None, None)
+
+            with self.assertRaises(RuntimeError):
+                self.service.do_get_by_dct_type_with_bpnl(
+                    bpnl=bpnl,
+                    counter_party_address=counter_party_address,
+                    dct_type=dct_type,
+                )
+
+    def test_do_put_by_dct_type_with_bpnl_success(self):
+        """Test do_put_by_dct_type_with_bpnl delegates to do_put_with_bpnl with the correct filter expression."""
+        bpnl = "BPNL000000000001"
+        counter_party_address = "https://provider.example.com/api/v1/dsp"
+        dct_type = "https://w3id.org/catenax/taxonomy#PcfExchange"
+        json_data = {"pcfValue": 3.14}
+        policies = [{"@id": "policy-456"}]
+        path = "/pcf"
+        mock_response = mock.Mock(spec=Response)
+
+        with mock.patch.object(self.service, 'do_put_with_bpnl') as mock_do_put:
+            mock_do_put.return_value = mock_response
+
+            result = self.service.do_put_by_dct_type_with_bpnl(
+                bpnl=bpnl,
+                counter_party_address=counter_party_address,
+                dct_type=dct_type,
+                json=json_data,
+                policies=policies,
+                path=path,
+            )
+
+            self.assertEqual(result, mock_response)
+            mock_do_put.assert_called_once()
+            call_kwargs = mock_do_put.call_args[1]
+            self.assertEqual(call_kwargs["bpnl"], bpnl)
+            self.assertEqual(call_kwargs["counter_party_address"], counter_party_address)
+            self.assertEqual(call_kwargs["json"], json_data)
+            self.assertEqual(call_kwargs["policies"], policies)
+            self.assertEqual(call_kwargs["path"], path)
+            filter_expr = call_kwargs["filter_expression"]
+            self.assertEqual(len(filter_expr), 1)
+            self.assertIn(dct_type, str(filter_expr[0]))
+
+    def test_do_put_by_dct_type_with_bpnl_uses_bpnl_for_discovery(self):
+        """Test that do_put_by_dct_type_with_bpnl triggers BPNL-based discovery (Saturn-aware URL resolution)."""
+        bpnl = "BPNL000000000001"
+        counter_party_address = "https://provider.example.com/api/v1/dsp"
+        dct_type = "https://w3id.org/catenax/taxonomy#PcfExchange"
+        json_data = {"pcfValue": 1.0}
+        dataplane_url = "https://dataplane.example.com"
+        access_token = "token-xyz"
+        mock_response = mock.Mock(spec=Response)
+
+        with mock.patch.object(self.service, 'do_dsp_with_bpnl') as mock_dsp, \
+             mock.patch.object(self.service, '_execute_http_request') as mock_execute:
+            mock_dsp.return_value = (dataplane_url, access_token)
+            mock_execute.return_value = mock_response
+
+            result = self.service.do_put_by_dct_type_with_bpnl(
+                bpnl=bpnl,
+                counter_party_address=counter_party_address,
+                dct_type=dct_type,
+                json=json_data,
+            )
+
+            self.assertEqual(result, mock_response)
+            # do_dsp_with_bpnl must be called, ensuring Saturn discovery endpoint is used
+            mock_dsp.assert_called_once()
+            dsp_kwargs = mock_dsp.call_args[1]
+            self.assertEqual(dsp_kwargs["bpnl"], bpnl)
+            self.assertEqual(dsp_kwargs["counter_party_address"], counter_party_address)
+
+    def test_do_put_by_dct_type_with_bpnl_missing_dataplane(self):
+        """Test do_put_by_dct_type_with_bpnl raises RuntimeError when DSP returns no dataplane info."""
+        bpnl = "BPNL000000000001"
+        counter_party_address = "https://provider.example.com/api/v1/dsp"
+        dct_type = "https://w3id.org/catenax/taxonomy#PcfExchange"
+
+        with mock.patch.object(self.service, 'do_dsp_with_bpnl') as mock_dsp:
+            mock_dsp.return_value = (None, None)
+
+            with self.assertRaises(RuntimeError):
+                self.service.do_put_by_dct_type_with_bpnl(
+                    bpnl=bpnl,
+                    counter_party_address=counter_party_address,
+                    dct_type=dct_type,
+                )
+
+    def test_do_get_by_dct_type_with_bpnl_custom_dct_type_key(self):
+        """Test do_get_by_dct_type_with_bpnl with a custom dct_type_key."""
+        bpnl = "BPNL000000000001"
+        counter_party_address = "https://provider.example.com/api/v1/dsp"
+        dct_type = "PcfExchange"
+        custom_key = "dct:type"
+        mock_response = mock.Mock(spec=Response)
+
+        with mock.patch.object(self.service, 'do_get_with_bpnl') as mock_do_get:
+            mock_do_get.return_value = mock_response
+
+            self.service.do_get_by_dct_type_with_bpnl(
+                bpnl=bpnl,
+                counter_party_address=counter_party_address,
+                dct_type=dct_type,
+                dct_type_key=custom_key,
+            )
+
+            call_kwargs = mock_do_get.call_args[1]
+            filter_expr = call_kwargs["filter_expression"]
+            self.assertIn(custom_key, str(filter_expr[0]))
+            self.assertIn(dct_type, str(filter_expr[0]))
+
+    def test_do_put_by_dct_type_with_bpnl_custom_dct_type_key(self):
+        """Test do_put_by_dct_type_with_bpnl with a custom dct_type_key."""
+        bpnl = "BPNL000000000001"
+        counter_party_address = "https://provider.example.com/api/v1/dsp"
+        dct_type = "PcfExchange"
+        custom_key = "dct:type"
+        mock_response = mock.Mock(spec=Response)
+
+        with mock.patch.object(self.service, 'do_put_with_bpnl') as mock_do_put:
+            mock_do_put.return_value = mock_response
+
+            self.service.do_put_by_dct_type_with_bpnl(
+                bpnl=bpnl,
+                counter_party_address=counter_party_address,
+                dct_type=dct_type,
+                dct_type_key=custom_key,
+            )
+
+            call_kwargs = mock_do_put.call_args[1]
+            filter_expr = call_kwargs["filter_expression"]
+            self.assertIn(custom_key, str(filter_expr[0]))
+            self.assertIn(dct_type, str(filter_expr[0]))
+
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## WHAT

This pull request introduces two new convenience methods for asset access by DCT type in the Saturn connector consumer service, along with comprehensive unit tests for these methods.

## WHY

To be able to use them.

Closes #217
