### PR TITLE
feat: add inline_data data_address support to asset creation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -21,6 +21,6 @@
 #################################################################################
 
 # tractusx_sdk Package-level variables
-__version__ = '0.8.0-rc2'
+__version__ = '0.8.0-rc3'
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"

--- a/docs/api-reference/dataspace-library/connector/services.md
+++ b/docs/api-reference/dataspace-library/connector/services.md
@@ -163,7 +163,8 @@ Combined:
 | `get_filter_expression`    | `filter_params`                                | Build filter expression for catalog queries      |
 | `contract_negotiations`    | `counter_party_id`, `asset_id`, `policies`     | List or manage contract negotiations             |
 | `transfer_processes`       | `contract_id`, `asset_id`                      | List or manage data transfer processes           |
-| `create_asset`             | `asset_id`, `base_url`, `dct_type`, `version`, `semantic_id` | Create and publish an asset                      |
+| `create_asset`             | `asset_id`, `base_url` *(or `inline_data`)*, `dct_type`, `version`, `semantic_id` | Create and publish an asset with an HttpData or InlineData DataAddress |
+| `create_inline_asset`      | `asset_id`, `data`, `content_type`, `dct_type`, `version`, `semantic_id` | Convenience wrapper to create an asset with an embedded InlineData payload |
 | `create_contract`          | `contract_params`                              | Create a contract definition                     |
 | `create_policy`            | `policy_params`                                | Create a policy for data sharing                 |
 | `assets`                   | `asset_id`, `asset_data`                       | Manage assets (CRUD operations)                  |
@@ -367,7 +368,8 @@ The Saturn `ConnectorProviderService` is identical to the base. All methods are 
 
 | Method | Key Parameters | Description |
 |--------|---------------|-------------|
-| `create_asset(asset_id, base_url, dct_type, version, semantic_id, proxy_params, headers, private_properties, ...)` | `asset_id: str`, `base_url: str` | Build and POST a complete EDC asset (data address + properties + private properties) |
+| `create_asset(asset_id, base_url, dct_type, version, semantic_id, proxy_params, headers, inline_data, content_type, private_properties, ...)` | `asset_id: str`; one of `base_url: str` **or** `inline_data: str` | Build and POST a complete EDC asset. Use `base_url` for HttpData assets or `inline_data`/`content_type` for InlineData assets. Raises `ValueError` if neither is provided. |
+| `create_inline_asset(asset_id, data, content_type, dct_type, version, semantic_id, private_properties, ...)` | `asset_id: str`, `data: str` | Convenience wrapper around `create_asset()` for embedding data directly in the DataAddress (InlineData type). `content_type` defaults to `application/json`. |
 | `create_contract(asset_id, access_policy_id, usage_policy_id, ...)` | `asset_id: str` | Build and POST a contract definition linking an asset to access and usage policies |
 | `create_policy(policy_id, permissions, ...)` | `policy_id: str` | Build and POST an ODRL policy |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,7 +157,7 @@ You manage data catalogs, build data pipelines, or implement governance policies
 !!! tip "New to dataspaces?"
     Check out the [Getting Started Guide](tutorials/getting-started.md) - it takes about 10 minutes and shows you how the whole thing works.
 
-!!! info "Current release: 0.8.0-rc2"
+!!! info "Current release: 0.8.0-rc3"
     Requires Python 3.12+  
     License: Apache 2.0 (code) / CC-BY-4.0 (docs)
 

--- a/docs/tutorials/create-first-asset.md
+++ b/docs/tutorials/create-first-asset.md
@@ -300,6 +300,95 @@ python connect.py
 !!! success "Data Access Complete!"
     Congratulations! You've successfully created an asset and accessed it.
 
+### Create an Inline Data Asset
+
+Instead of pointing to an external HTTP endpoint, you can embed the data payload **directly inside the asset** using the `InlineData` DataAddress type. This is useful for publishing small or static payloads (e.g. JSON documents, certificates, metadata) without requiring a separate backend server.
+
+Use the `create_inline_asset()` convenience method:
+
+```python
+import json
+from tractusx_sdk.dataspace.services.connector import BaseConnectorProviderService
+from tractusx_sdk.dataspace.services.connector.service_factory import ServiceFactory
+import logging
+
+# Step 1: Configure your connector settings
+consumer_connector_controlplane_hostname = "https://connector.example.com"
+consumer_connector_controlplane_management_api = "/management"
+consumer_api_key_header = "X-Api-Key"
+consumer_api_key = "your-api-key"
+consumer_dataspace_version = "jupiter"  # or "saturn" for latest
+
+# Step 2: Set up headers for API authentication
+consumer_connector_headers = {
+    consumer_api_key_header: consumer_api_key,
+    "Content-Type": "application/json"
+}
+
+# Step 3: Initialize logger
+logger = logging.getLogger(__name__)
+
+# Step 4: Create connector service using ServiceFactory
+provider_connector_service: BaseConnectorProviderService = ServiceFactory.get_connector_provider_service(
+    dataspace_version=consumer_dataspace_version,
+    base_url=consumer_connector_controlplane_hostname,
+    dma_path=consumer_connector_controlplane_management_api,
+    headers=consumer_connector_headers,
+    logger=logger,
+    verbose=True
+)
+
+# Step 5: Define the payload to embed
+payload = {
+    "id": "doc-001",
+    "type": "ExampleDocument",
+    "value": "Hello, dataspace!"
+}
+
+# Step 6: Create the inline asset
+try:
+    response = provider_connector_service.create_inline_asset(
+        asset_id="inline-asset-001",
+        data=json.dumps(payload),          # Serialized payload embedded in the asset
+        content_type="application/json",   # Optional, defaults to "application/json"
+        dct_type="example-type",
+        version="1.0"
+    )
+
+    print(" Inline asset created!")
+    print(response)
+
+except Exception as e:
+    print(f" Failed to create inline asset: {e}")
+```
+
+Alternatively, you can use `create_asset()` directly with the `inline_data` parameter:
+
+```python
+response = provider_connector_service.create_asset(
+    asset_id="inline-asset-001",
+    inline_data=json.dumps(payload),
+    content_type="application/json",
+    dct_type="example-type",
+    version="1.0"
+)
+```
+
+!!! info "How InlineData works"
+    The payload is stored inside the EDC asset's DataAddress under the `data` field:
+    ```json
+    {
+        "@type": "DataAddress",
+        "type": "InlineData",
+        "data": "{\"id\": \"doc-001\", ...}",
+        "mediaType": "application/json"
+    }
+    ```
+    When a consumer negotiates a contract and requests the asset via the data plane, the EDC serves the embedded content directly — no additional backend endpoint required.
+
+!!! warning "Validation"
+    `create_asset()` raises a `ValueError` if neither `base_url` nor `inline_data` is provided. You must supply exactly one of the two.
+
 ### Troubleshooting
 
 If you encounter issues, here are common solutions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "tractusx_sdk"
-version = "0.8.0-rc2"
+version = "0.8.0-rc3"
 description = "Eclipse Tractus-X Software Development KIT - The Dataspace & Industry Foundation Middleware"
 license = { text = "Apache-2.0" }
 readme = "README.md"

--- a/src/tractusx_sdk/__init__.py
+++ b/src/tractusx_sdk/__init__.py
@@ -20,6 +20,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #################################################################################
 
-__version__ = '0.8.0-rc2'
+__version__ = '0.8.0-rc3'
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"

--- a/src/tractusx_sdk/dataspace/__init__.py
+++ b/src/tractusx_sdk/dataspace/__init__.py
@@ -21,6 +21,6 @@
 #################################################################################
 
 # Package-level variables
-__version__ = '0.8.0-rc2'
+__version__ = '0.8.0-rc3'
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"

--- a/src/tractusx_sdk/dataspace/services/connector/base_connector_provider.py
+++ b/src/tractusx_sdk/dataspace/services/connector/base_connector_provider.py
@@ -124,9 +124,19 @@ class BaseConnectorProviderService(BaseService):
         :param inline_data: Raw data string to embed in an InlineData DataAddress.
         :param content_type: Media type for InlineData (default ``"application/json"``).
         :param kwargs: Additional keyword arguments forwarded to the model factory.
-        :raises ValueError: If neither ``base_url`` nor ``inline_data`` is provided.
+        :raises ValueError: In the following cases:
+
+            - Both ``base_url`` and ``inline_data`` are provided (ambiguous input).
+            - ``data_address_type`` is ``"InlineData"`` but ``inline_data`` is ``None``.
+            - Neither ``base_url`` nor ``inline_data`` is provided.
+            - The EDC connector returns a non-200 response when creating the asset.
         """
         # Determine effective data address type from parameters
+        if base_url is not None and inline_data is not None:
+            raise ValueError(
+                "Provide either 'base_url' (HttpData) or 'inline_data' (InlineData), not both."
+            )
+
         if inline_data is not None:
             data_address_type = "InlineData"
 

--- a/src/tractusx_sdk/dataspace/services/connector/base_connector_provider.py
+++ b/src/tractusx_sdk/dataspace/services/connector/base_connector_provider.py
@@ -86,7 +86,7 @@ class BaseConnectorProviderService(BaseService):
     def create_asset(
         self,
         asset_id: str,
-        base_url: str,
+        base_url: str = None,
         dct_type: str = None,
         version: str = "3.0",
         semantic_id: str = None,
@@ -100,10 +100,47 @@ class BaseConnectorProviderService(BaseService):
         private_properties: dict = None,
         context: dict = None,
         data_address_type: str = "HttpData",
+        inline_data: str = None,
+        content_type: str = None,
         **kwargs
     ):
+        """
+        Create an EDC asset with either an HttpData or InlineData DataAddress.
+
+        For HttpData (default): provide ``base_url`` (and optionally ``proxy_params`` / ``headers``).
+        For InlineData: provide ``inline_data`` (the raw content to embed) and optionally
+        ``content_type`` (defaults to ``"application/json"``).
+
+        :param asset_id: Unique identifier for the asset.
+        :param base_url: Backend URL for HttpData assets. Optional when using InlineData.
+        :param dct_type: DCT type URI for the asset properties.
+        :param version: Dataspace version string (default ``"3.0"``).
+        :param semantic_id: Semantic ID URI for the asset properties.
+        :param proxy_params: Proxy configuration for HttpData assets. Ignored for InlineData.
+        :param headers: Custom headers for HttpData assets. Ignored for InlineData.
+        :param private_properties: Private properties dict for the asset.
+        :param context: JSON-LD context dict. Uses EDC defaults if not provided.
+        :param data_address_type: DataAddress type (``"HttpData"`` or ``"InlineData"``).
+        :param inline_data: Raw data string to embed in an InlineData DataAddress.
+        :param content_type: Media type for InlineData (default ``"application/json"``).
+        :param kwargs: Additional keyword arguments forwarded to the model factory.
+        :raises ValueError: If neither ``base_url`` nor ``inline_data`` is provided.
+        """
+        # Determine effective data address type from parameters
+        if inline_data is not None:
+            data_address_type = "InlineData"
+
+        if data_address_type == "InlineData" and inline_data is None:
+            raise ValueError("inline_data is required when data_address_type is 'InlineData'.")
+
+        if data_address_type != "InlineData" and base_url is None:
+            raise ValueError("base_url is required when data_address_type is not 'InlineData'.")
+
         if self.verbose:
-            self.logger.info(f"Creating asset {asset_id} at {base_url}.")
+            if data_address_type == "InlineData":
+                self.logger.info(f"Creating inline asset {asset_id}.")
+            else:
+                self.logger.info(f"Creating asset {asset_id} at {base_url}.")
 
         # Use provided context or default
         if context is None:
@@ -114,18 +151,27 @@ class BaseConnectorProviderService(BaseService):
                 "dct": "http://purl.org/dc/terms/"
             }
 
-        data_address = {
-            "@type": "DataAddress",
-            "type": data_address_type,
-            "baseUrl": base_url
-        }
+        # Build DataAddress based on type
+        if data_address_type == "InlineData":
+            data_address = {
+                "@type": "DataAddress",
+                "type": "InlineData",
+                "data": inline_data,
+                "mediaType": content_type or "application/json"
+            }
+        else:
+            data_address = {
+                "@type": "DataAddress",
+                "type": data_address_type,
+                "baseUrl": base_url
+            }
 
-        if proxy_params is not None:
-            data_address.update(proxy_params)
+            if proxy_params is not None:
+                data_address.update(proxy_params)
 
-        if headers is not None:
-            for key, value in headers.items():
-                data_address["header:" + key] = value
+            if headers is not None:
+                for key, value in headers.items():
+                    data_address["header:" + key] = value
 
         properties: dict = {}
 
@@ -164,6 +210,50 @@ class BaseConnectorProviderService(BaseService):
             self.logger.info(f"Asset {asset_id} created successfully.")
 
         return asset_response.json()
+
+    def create_inline_asset(
+        self,
+        asset_id: str,
+        data: str,
+        content_type: str = "application/json",
+        dct_type: str = None,
+        version: str = "3.0",
+        semantic_id: str = None,
+        private_properties: dict = None,
+        context: dict = None,
+        **kwargs
+    ):
+        """
+        Convenience method to create an EDC asset with an InlineData DataAddress.
+
+        The ``data`` payload is embedded directly in the asset's DataAddress so
+        that the EDC data plane can serve it without an external backend.
+
+        :param asset_id: Unique identifier for the asset.
+        :param data: Raw content string to embed (e.g. a JSON document).
+        :param content_type: Media type of the embedded data (default ``"application/json"``).
+        :param dct_type: DCT type URI for the asset properties.
+        :param version: Dataspace version string (default ``"3.0"``).
+        :param semantic_id: Semantic ID URI for the asset properties.
+        :param private_properties: Private properties dict for the asset.
+        :param context: JSON-LD context dict. Uses EDC defaults if not provided.
+        :param kwargs: Additional keyword arguments forwarded to the model factory.
+        :return: The created asset response as a dict.
+        """
+        return self.create_asset(
+            asset_id=asset_id,
+            inline_data=data,
+            content_type=content_type,
+            dct_type=dct_type,
+            version=version,
+            semantic_id=semantic_id,
+            proxy_params=None,
+            headers=None,
+            private_properties=private_properties,
+            context=context,
+            data_address_type="InlineData",
+            **kwargs
+        )
 
     def create_contract(
         self,

--- a/src/tractusx_sdk/extensions/__init__.py
+++ b/src/tractusx_sdk/extensions/__init__.py
@@ -29,6 +29,6 @@ This module contains extensions for the Tractus-X SDK, including:
 - tck: Tools, Checkers, and Helpers for various SDK components
 """
 
-__version__ = '0.8.0-rc2'
+__version__ = '0.8.0-rc3'
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"

--- a/src/tractusx_sdk/industry/__init__.py
+++ b/src/tractusx_sdk/industry/__init__.py
@@ -21,7 +21,7 @@
 #################################################################################
 
 # Package-level variables
-__version__ = '0.8.0-rc2'
+__version__ = '0.8.0-rc3'
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"
 

--- a/tests/dataspace/services/connector/test_base_connector_provider.py
+++ b/tests/dataspace/services/connector/test_base_connector_provider.py
@@ -195,3 +195,108 @@ def test_create_asset_no_verbose_logging(mock_get_asset_model, mock_dma_adapter,
     service.create_asset(asset_id="123", base_url="http://test", dct_type="test")
 
     logger.info.assert_not_called()
+
+
+# ── InlineData DataAddress tests ──────────────────────────────────────────────
+
+
+@patch("tractusx_sdk.dataspace.models.connector.ModelFactory.get_asset_model")
+def test_create_asset_inline_data_success(mock_get_asset_model, service):
+    """Verify that providing inline_data builds an InlineData DataAddress."""
+    mock_response = Mock(status_code=200)
+    mock_response.json.return_value = {"asset": "ok"}
+    service._asset_controller.create.return_value = mock_response
+    mock_get_asset_model.return_value = Mock(to_data=lambda: "{}")
+
+    result = service.create_asset(
+        asset_id="inline-1",
+        inline_data='{"hello": "world"}',
+        content_type="application/json",
+        dct_type="test-type"
+    )
+
+    assert result == {"asset": "ok"}
+    call_kwargs = mock_get_asset_model.call_args
+    data_address = call_kwargs.kwargs["data_address"]
+    assert data_address["type"] == "InlineData"
+    assert data_address["data"] == '{"hello": "world"}'
+    assert data_address["mediaType"] == "application/json"
+    assert "baseUrl" not in data_address
+
+
+@patch("tractusx_sdk.dataspace.models.connector.ModelFactory.get_asset_model")
+def test_create_asset_inline_data_default_content_type(mock_get_asset_model, service):
+    """Verify that content_type defaults to 'application/json' for InlineData."""
+    mock_response = Mock(status_code=200)
+    mock_response.json.return_value = {"asset": "ok"}
+    service._asset_controller.create.return_value = mock_response
+    mock_get_asset_model.return_value = Mock(to_data=lambda: "{}")
+
+    service.create_asset(asset_id="inline-2", inline_data="data")
+
+    call_kwargs = mock_get_asset_model.call_args
+    data_address = call_kwargs.kwargs["data_address"]
+    assert data_address["mediaType"] == "application/json"
+
+
+@patch("tractusx_sdk.dataspace.models.connector.ModelFactory.get_asset_model")
+def test_create_asset_inline_data_ignores_proxy_and_headers(mock_get_asset_model, service):
+    """Verify that proxy_params and headers are ignored for InlineData assets."""
+    mock_response = Mock(status_code=200)
+    mock_response.json.return_value = {"asset": "ok"}
+    service._asset_controller.create.return_value = mock_response
+    mock_get_asset_model.return_value = Mock(to_data=lambda: "{}")
+
+    service.create_asset(
+        asset_id="inline-3",
+        inline_data="payload",
+        proxy_params={"proxyPath": "true"},
+        headers={"Authorization": "Bearer token"}
+    )
+
+    call_kwargs = mock_get_asset_model.call_args
+    data_address = call_kwargs.kwargs["data_address"]
+    assert "proxyPath" not in data_address
+    assert "header:Authorization" not in data_address
+
+
+def test_create_asset_no_base_url_no_inline_data_raises(service):
+    """Verify ValueError when neither base_url nor inline_data is provided."""
+    with pytest.raises(ValueError, match="base_url is required"):
+        service.create_asset(asset_id="bad-1", dct_type="test")
+
+
+def test_create_asset_inline_data_type_without_data_raises(service):
+    """Verify ValueError when data_address_type is InlineData but inline_data is None."""
+    with pytest.raises(ValueError, match="inline_data is required"):
+        service.create_asset(
+            asset_id="bad-2",
+            data_address_type="InlineData",
+            dct_type="test"
+        )
+
+
+@patch("tractusx_sdk.dataspace.models.connector.ModelFactory.get_asset_model")
+def test_create_inline_asset_convenience(mock_get_asset_model, service):
+    """Verify the create_inline_asset() convenience method delegates correctly."""
+    mock_response = Mock(status_code=200)
+    mock_response.json.return_value = {"asset": "inline-ok"}
+    service._asset_controller.create.return_value = mock_response
+    mock_get_asset_model.return_value = Mock(to_data=lambda: "{}")
+
+    result = service.create_inline_asset(
+        asset_id="conv-1",
+        data='{"cert": "data"}',
+        content_type="application/json",
+        dct_type="https://w3id.org/catenax/taxonomy#CompanyCertificate",
+        semantic_id="urn:samm:io.catenax.cert:3.1.0"
+    )
+
+    assert result == {"asset": "inline-ok"}
+    call_kwargs = mock_get_asset_model.call_args
+    data_address = call_kwargs.kwargs["data_address"]
+    assert data_address["type"] == "InlineData"
+    assert data_address["data"] == '{"cert": "data"}'
+    props = call_kwargs.kwargs["properties"]
+    assert props["dct:type"]["@id"] == "https://w3id.org/catenax/taxonomy#CompanyCertificate"
+    assert props["aas-semantics:semanticId"]["@id"] == "urn:samm:io.catenax.cert:3.1.0"


### PR DESCRIPTION
## WHAT

This pull request introduces support for creating EDC assets with inline (embedded) data, in addition to the existing HTTP-based assets. It adds a new `create_inline_asset` convenience method, updates the core asset creation logic to handle inline data, and provides comprehensive tests for these new capabilities.

## WHY

These changes make it possible to create and test EDC assets that do not require an external backend, improving flexibility for dataspace scenarios.


Closes #221